### PR TITLE
Implement no_std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,9 @@ jobs:
           target: ${{matrix.target}}
       - uses: actions/checkout@v4
       - name: Build
-        run: cargo build --workspace --release
+        run: cargo build --workspace --release --all-features
+      - name: Build (no_std)
+        run: cargo build --workspace --release --no-default-features --features=encoder,optimization
       - name: Run tests
         run: cargo test --workspace --release --all-features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2025-07-26
+
+### Added
+
+- Added no_std support by disabling the new `std` feature that is enabled by default. Custom traits and default
+  implementation for &[u8] and &mut [u8] are provided.
+
 ## 0.5.1 - 2025-07-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,20 +5,21 @@ homepage = "https://github.com/hasenbanck/lzma-rust2/"
 name = "lzma-rust2"
 repository = "https://github.com/hasenbanck/lzma-rust2/"
 rust-version = "1.85"
-version = "0.5.1"
+version = "0.6.0"
 keywords = ["lzma"]
 license = "Apache-2.0"
 exclude = ["/tests/data"]
 
 [features]
-default = ["optimization", "encoder"]
+default = ["std", "optimization", "encoder"]
+std = []
 optimization = []
 encoder = []
 
 [dependencies]
 
 [dev-dependencies]
-criterion = { version = "0.6", features = ["html_reports"] }
+criterion = { version = "0.7", features = ["html_reports"] }
 liblzma = { version = "0.4", features = ["static"] }
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ Encoding is also well optimized and is surpassing `liblzma` for level 0 to 3 and
 
 Data was assembled using lzma-rust2 v0.4.0 and liblzma v0.4.2.
 
+## no_std Support
+
+This crate supports `no_std` environments by disabling the default `std` feature.
+
+When used in `no_std` mode, the crate provides custom `Read`, `Write`, and `Error` types
+(defined in `no_std.rs`) that are compatible with `no_std` environments. These types offer
+similar functionality to their `std::io` counterparts but are implemented using only `core`
+and `alloc`.
+
+The custom types include:
+
+- [`Error`]: A custom error enum with variants for different error conditions.
+- [`Read`]: A trait similar to `std::io::Read`.
+- [`Write`]: A trait similar to `std::io::Write`.
+
+Default implementations for `&[u8]` (Read) and `&mut [u8]` (Write) are provided.
+
+Note that multithreaded features are not available in `no_std` mode as they require
+standard library threading primitives.
+
 ## License
 
 Licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,6 +1,10 @@
-use std::io::Result;
+use alloc::{vec, vec::Vec};
 
-use super::{lz::LZDecoder, range_dec::RangeDecoder, *};
+use super::{
+    coder_get_dict_size, lz::LZDecoder, range_dec::RangeDecoder, LZMACoder, LengthCoder,
+    LiteralCoder, LiteralSubCoder, ALIGN_BITS, DIST_MODEL_END, DIST_MODEL_START, LOW_SYMBOLS,
+    MATCH_LEN_MIN, MID_SYMBOLS,
+};
 use crate::range_dec::RangeReader;
 
 pub(crate) struct LZMADecoder {
@@ -47,7 +51,7 @@ impl LZMADecoder {
         &mut self,
         lz: &mut LZDecoder,
         rc: &mut RangeDecoder<R>,
-    ) -> Result<()> {
+    ) -> crate::Result<()> {
         lz.repeat_pending()?;
         while lz.has_space() {
             let pos_state = lz.get_pos() as u32 & self.coder.pos_mask;
@@ -162,7 +166,7 @@ impl LiteralDecoder {
         coder: &mut LZMACoder,
         lz: &mut LZDecoder,
         rc: &mut RangeDecoder<R>,
-    ) -> Result<()> {
+    ) -> crate::Result<()> {
         let i = self
             .coder
             .get_sub_coder_index(lz.get_byte(0) as _, lz.get_pos() as _);
@@ -188,7 +192,7 @@ impl LiteralSubDecoder {
         coder: &mut LZMACoder,
         lz: &mut LZDecoder,
         rc: &mut RangeDecoder<R>,
-    ) -> Result<()> {
+    ) -> crate::Result<()> {
         let mut symbol: u32 = 1;
         let liter = coder.state.is_literal();
         if liter {

--- a/src/enc/encoder_normal.rs
+++ b/src/enc/encoder_normal.rs
@@ -1,3 +1,5 @@
+use alloc::{vec, vec::Vec};
+
 use super::{
     encoder::{LZMAEncoder, LZMAEncoderTrait},
     lz::{LZEncoder, MFType},

--- a/src/enc/lzma2_writer_mt.rs
+++ b/src/enc/lzma2_writer_mt.rs
@@ -139,7 +139,7 @@ impl<W: Write> LZMA2WriterMT<W> {
             }
         }
 
-        let work_unit = std::mem::take(&mut self.current_work_unit);
+        let work_unit = core::mem::take(&mut self.current_work_unit);
 
         if !self
             .work_queue

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -2,12 +2,14 @@ mod encoder;
 mod encoder_fast;
 mod encoder_normal;
 mod lzma2_writer;
+#[cfg(feature = "std")]
 mod lzma2_writer_mt;
 mod lzma_writer;
 mod range_enc;
 
 pub use encoder::EncodeMode;
 pub use lzma2_writer::*;
+#[cfg(feature = "std")]
 pub use lzma2_writer_mt::*;
 pub use lzma_writer::*;
 

--- a/src/lz/aligned_memory.rs
+++ b/src/lz/aligned_memory.rs
@@ -1,5 +1,5 @@
-use std::{
-    alloc::{alloc_zeroed, dealloc, Layout},
+use alloc::alloc::{alloc_zeroed, dealloc, Layout};
+use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
     ptr::NonNull,
@@ -70,7 +70,7 @@ impl AsRef<[i32]> for AlignedMemoryI32 {
     fn as_ref(&self) -> &[i32] {
         // SAFETY: Points to a valid region in space that is allocated, aligned, initialized and
         // of length target_length * size_of::<i32>()
-        unsafe { std::slice::from_raw_parts(self.ptr.cast::<i32>().as_ptr(), self.target_length) }
+        unsafe { core::slice::from_raw_parts(self.ptr.cast::<i32>().as_ptr(), self.target_length) }
     }
 }
 
@@ -79,7 +79,7 @@ impl AsMut<[i32]> for AlignedMemoryI32 {
         // SAFETY: Points to a valid region in space that is allocated, aligned, initialized and
         // of length target_length * size_of::<i32>()
         unsafe {
-            std::slice::from_raw_parts_mut(self.ptr.cast::<i32>().as_ptr(), self.target_length)
+            core::slice::from_raw_parts_mut(self.ptr.cast::<i32>().as_ptr(), self.target_length)
         }
     }
 }

--- a/src/lz/bt4.rs
+++ b/src/lz/bt4.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "optimization"))]
+use alloc::{vec, vec::Vec};
+
 #[cfg(feature = "optimization")]
 use super::AlignedMemoryI32;
 use super::{extend_match, hash234::Hash234, LZEncoder, MatchFind, Matches};

--- a/src/lz/hash234.rs
+++ b/src/lz/hash234.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "optimization"))]
+use alloc::{vec, vec::Vec};
+
 #[cfg(feature = "optimization")]
 use super::AlignedMemoryI32;
 use super::LZEncoder;

--- a/src/lz/hc4.rs
+++ b/src/lz/hc4.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "optimization"))]
+use alloc::{vec, vec::Vec};
+
 #[cfg(feature = "optimization")]
 use super::AlignedMemoryI32;
 use super::{

--- a/src/lz/lz_decoder.rs
+++ b/src/lz/lz_decoder.rs
@@ -1,4 +1,6 @@
-use std::io::{ErrorKind, Read};
+use alloc::{vec, vec::Vec};
+
+use crate::{error_other, Read};
 
 #[derive(Default)]
 pub(crate) struct LZDecoder {
@@ -76,12 +78,9 @@ impl LZDecoder {
         }
     }
 
-    pub(crate) fn repeat(&mut self, dist: usize, len: usize) -> std::io::Result<()> {
+    pub(crate) fn repeat(&mut self, dist: usize, len: usize) -> crate::Result<()> {
         if dist >= self.full {
-            return Err(std::io::Error::new(
-                ErrorKind::InvalidInput,
-                "dist overflow",
-            ));
+            return Err(error_other("dist overflow"));
         }
         let mut left = usize::min(self.limit - self.pos, len);
         self.pending_len = len - left;
@@ -134,7 +133,7 @@ impl LZDecoder {
         Ok(())
     }
 
-    pub(crate) fn repeat_pending(&mut self) -> std::io::Result<()> {
+    pub(crate) fn repeat_pending(&mut self) -> crate::Result<()> {
         if self.pending_len > 0 {
             self.repeat(self.pending_dist, self.pending_len)?;
         }
@@ -145,7 +144,7 @@ impl LZDecoder {
         &mut self,
         mut in_data: R,
         len: usize,
-    ) -> std::io::Result<()> {
+    ) -> crate::Result<()> {
         let copy_size = (self.buf_size - self.pos).min(len);
         let buf = &mut self.buf[self.pos..(self.pos + copy_size)];
         in_data.read_exact(buf)?;

--- a/src/lz/mod.rs
+++ b/src/lz/mod.rs
@@ -129,7 +129,8 @@ fn extend_match_safe(s1: &[u8], s2: &[u8]) -> usize {
                     target_endian = "little",
                     all(target_arch = "x86_64", target_feature = "bmi1")
                 ))]
-                let matching_bytes = (std::arch::x86_64::_tzcnt_u64(diff_bits as u64) / 8) as usize;
+                let matching_bytes =
+                    (core::arch::x86_64::_tzcnt_u64(diff_bits as u64) / 8) as usize;
 
                 #[cfg(target_endian = "big")]
                 let matching_bytes = (diff_bits.leading_zeros() / 8) as usize;

--- a/src/lzma2_reader_mt.rs
+++ b/src/lzma2_reader_mt.rs
@@ -189,7 +189,7 @@ impl<R: Read> LZMA2ReaderMT<R> {
         }
 
         let work_unit =
-            std::mem::replace(&mut self.current_work_unit, Vec::with_capacity(1024 * 1024));
+            core::mem::replace(&mut self.current_work_unit, Vec::with_capacity(1024 * 1024));
 
         if !self
             .work_queue

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -1,0 +1,143 @@
+use alloc::vec::Vec;
+
+/// `no_std` compatible error type.
+///
+/// Will get removed once `std::io::Read` and `std::io::Write` are available for `no_std`.
+#[derive(Debug, Copy, Clone)]
+pub enum Error {
+    EOF,
+    Interrupted,
+    InvalidData(&'static str),
+    InvalidInput(&'static str),
+    OutOfMemory(&'static str),
+    Other(&'static str),
+    Unsupported(&'static str),
+    WriteZero(&'static str),
+}
+
+/// `no_std` compatible `std::io::Read` trait
+///
+/// Will get removed once there is a standard way in either `core` or `alloc`.
+pub trait Read {
+    fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize>;
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> crate::Result<()> {
+        default_read_exact(self, buf)
+    }
+}
+
+fn default_read_exact<R: Read + ?Sized>(this: &mut R, mut buf: &mut [u8]) -> crate::Result<()> {
+    while !buf.is_empty() {
+        match this.read(buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                buf = &mut buf[n..];
+            }
+            Err(Error::Interrupted) => {}
+            Err(e) => return Err(e),
+        }
+    }
+
+    if !buf.is_empty() {
+        Err(Error::EOF)
+    } else {
+        Ok(())
+    }
+}
+
+impl<R: Read> Read for &mut R {
+    #[inline(always)]
+    fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
+        (**self).read(buf)
+    }
+
+    #[inline(always)]
+    fn read_exact(&mut self, buf: &mut [u8]) -> crate::Result<()> {
+        (**self).read_exact(buf)
+    }
+}
+
+impl Read for &[u8] {
+    #[inline(always)]
+    fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
+        let length = self.len().min(buf.len());
+        let (left, right) = self.split_at(length);
+        buf[..length].copy_from_slice(left);
+        *self = right;
+        Ok(length)
+    }
+}
+
+/// `no_std` compatible `std::io::Write trait`
+///
+/// Will get removed once there is a standard way in either `core` or `alloc`.
+pub trait Write {
+    fn write(&mut self, buf: &[u8]) -> crate::Result<usize>;
+    fn flush(&mut self) -> crate::Result<()>;
+
+    fn write_all(&mut self, mut buf: &[u8]) -> crate::Result<()> {
+        while !buf.is_empty() {
+            match self.write(buf) {
+                Ok(0) => {
+                    return Err(Error::WriteZero("could not write any byte"));
+                }
+                Ok(n) => buf = &buf[n..],
+                Err(Error::Interrupted) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<W: Write> Write for &mut W {
+    #[inline(always)]
+    fn write(&mut self, buf: &[u8]) -> crate::Result<usize> {
+        (**self).write(buf)
+    }
+
+    #[inline(always)]
+    fn flush(&mut self) -> crate::Result<()> {
+        (**self).flush()
+    }
+}
+
+impl Write for &mut [u8] {
+    #[inline(always)]
+    fn write(&mut self, buf: &[u8]) -> crate::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        if self.is_empty() {
+            return Err(Error::WriteZero("&mut [u8] is too small"));
+        }
+
+        let write_len = buf.len().min(self.len());
+        self[..write_len].copy_from_slice(&buf[..write_len]);
+
+        let remaining = core::mem::take(self);
+        *self = &mut remaining[write_len..];
+
+        Ok(write_len)
+    }
+
+    #[inline(always)]
+    fn flush(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+}
+
+impl Write for Vec<u8> {
+    #[inline(always)]
+    fn write(&mut self, buf: &[u8]) -> crate::Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline(always)]
+    fn flush(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
no_std support by providing custom traits with default implementations for &[u8] and &mut [u8].

With the `std` feature enabled, everything stays the same as before.