### PR TITLE
style!: Rename identifiers to follow Rust API Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Deactivating the `optimization` feature will result in 100% standard Rust code.
 ## Performance
 
 The following part is strictly about single threaded performance. It supports multithreaded encoding and decoding
-through the `LZMA2WriterMT` and `LZMA2ReaderMT` structs though.
+through the `Lzma2WriterMt` and `Lzma2ReaderMt` structs though.
 
 When compared against the `liblzma` crate, which uses the C library of the same name, this crate has improved decoding
 speed.

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use liblzma::{bufread::*, stream::*};
+use liblzma::{bufread::*, stream};
 use lzma_rust2::{
-    LZIPOptions, LZIPReaderMT, LZIPWriter, LZIPWriterMT, LZMA2Options, LZMA2Reader, LZMA2ReaderMT,
-    LZMA2Writer, LZMA2WriterMT, LZMAOptions, LZMAReader, LZMAWriter, XZOptions, XZReaderMT,
-    XZWriter, XZWriterMT,
+    LzipOptions, LzipReaderMt, LzipWriter, LzipWriterMt, Lzma2Options, Lzma2Reader, Lzma2ReaderMt,
+    Lzma2Writer, Lzma2WriterMt, LzmaOptions, LzmaReader, LzmaWriter, XzOptions, XzReaderMt,
+    XzWriter, XzWriterMt,
 };
 
 static TEST_DATA: &[u8] = include_bytes!("../tests/data/executable.exe");
@@ -24,12 +24,12 @@ fn bench_compression_lzma(c: &mut Criterion) {
             BenchmarkId::new("lzma-rust2", level),
             &level,
             |b, &level| {
-                let option = LZMAOptions::with_preset(level);
+                let option = LzmaOptions::with_preset(level);
 
                 b.iter(|| {
                     let mut compressed = Vec::new();
                     let mut writer =
-                        LZMAWriter::new_no_header(black_box(&mut compressed), &option, true)
+                        LzmaWriter::new_no_header(black_box(&mut compressed), &option, true)
                             .unwrap();
                     writer.write_all(black_box(TEST_DATA)).unwrap();
                     writer.finish().unwrap();
@@ -39,10 +39,10 @@ fn bench_compression_lzma(c: &mut Criterion) {
         );
 
         group.bench_with_input(BenchmarkId::new("liblzma", level), &level, |b, &level| {
-            let option = LzmaOptions::new_preset(level).unwrap();
+            let option = stream::LzmaOptions::new_preset(level).unwrap();
             b.iter(|| {
                 let mut compressed = Vec::new();
-                let stream = Stream::new_lzma_encoder(&option).unwrap();
+                let stream = stream::Stream::new_lzma_encoder(&option).unwrap();
                 let mut encoder = XzEncoder::new_stream(black_box(TEST_DATA), stream);
                 encoder.read_to_end(black_box(&mut compressed)).unwrap();
                 black_box(compressed)
@@ -65,8 +65,8 @@ fn bench_compression_lzma2(c: &mut Criterion) {
             |b, &level| {
                 b.iter(|| {
                     let mut compressed = Vec::new();
-                    let option = LZMA2Options::with_preset(level);
-                    let mut writer = LZMA2Writer::new(black_box(&mut compressed), option);
+                    let option = Lzma2Options::with_preset(level);
+                    let mut writer = Lzma2Writer::new(black_box(&mut compressed), option);
                     writer.write_all(black_box(TEST_DATA)).unwrap();
                     writer.finish().unwrap();
                     black_box(compressed)
@@ -77,7 +77,7 @@ fn bench_compression_lzma2(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("liblzma", level), &level, |b, &level| {
             b.iter(|| {
                 let mut compressed = Vec::new();
-                let stream = Stream::new_easy_encoder(level, Check::None).unwrap();
+                let stream = stream::Stream::new_easy_encoder(level, stream::Check::None).unwrap();
                 let mut encoder = XzEncoder::new_stream(black_box(TEST_DATA), stream);
                 encoder.read_to_end(black_box(&mut compressed)).unwrap();
                 black_box(compressed)
@@ -98,18 +98,18 @@ fn bench_decompression_lzma(c: &mut Criterion) {
 
     for level in 0..=9 {
         {
-            let option = LZMAOptions::with_preset(level);
+            let option = LzmaOptions::with_preset(level);
             let mut compressed = Vec::new();
-            let mut writer = LZMAWriter::new_no_header(&mut compressed, &option, true).unwrap();
+            let mut writer = LzmaWriter::new_no_header(&mut compressed, &option, true).unwrap();
             writer.write_all(TEST_DATA).unwrap();
             writer.finish().unwrap();
             lzma_data.push((compressed, option));
         }
 
         {
-            let option = LzmaOptions::new_preset(level).unwrap();
+            let option = stream::LzmaOptions::new_preset(level).unwrap();
             let mut compressed = Vec::new();
-            let stream = Stream::new_lzma_encoder(&option).unwrap();
+            let stream = stream::Stream::new_lzma_encoder(&option).unwrap();
             let mut encoder = XzEncoder::new_stream(TEST_DATA, stream);
             encoder.read_to_end(black_box(&mut compressed)).unwrap();
             liblzma_data.push(compressed);
@@ -123,7 +123,7 @@ fn bench_decompression_lzma(c: &mut Criterion) {
             |b, (compressed, option)| {
                 b.iter(|| {
                     let mut uncompressed = Vec::new();
-                    let mut reader = LZMAReader::new(
+                    let mut reader = LzmaReader::new(
                         black_box(compressed.as_slice()),
                         TEST_DATA.len() as u64,
                         option.lc,
@@ -145,7 +145,7 @@ fn bench_decompression_lzma(c: &mut Criterion) {
             |b, compressed| {
                 b.iter(|| {
                     let mut uncompressed = Vec::new();
-                    let stream = Stream::new_lzma_decoder(256 * 1024 * 1024).unwrap();
+                    let stream = stream::Stream::new_lzma_decoder(256 * 1024 * 1024).unwrap();
                     let mut r = XzDecoder::new_stream(black_box(compressed.as_slice()), stream);
                     r.read_to_end(black_box(&mut uncompressed)).unwrap();
                     black_box(uncompressed)
@@ -166,10 +166,10 @@ fn bench_decompression_lzma2(c: &mut Criterion) {
     let mut liblzma_data = Vec::new();
 
     for level in 0..=9 {
-        let option = LZMA2Options::with_preset(level);
+        let option = Lzma2Options::with_preset(level);
         {
             let mut compressed = Vec::new();
-            let mut writer = LZMA2Writer::new(&mut compressed, option.clone());
+            let mut writer = Lzma2Writer::new(&mut compressed, option.clone());
             writer.write_all(TEST_DATA).unwrap();
             writer.finish().unwrap();
             lzma2_data.push((compressed, option));
@@ -177,7 +177,7 @@ fn bench_decompression_lzma2(c: &mut Criterion) {
 
         {
             let mut compressed = Vec::new();
-            let stream = Stream::new_easy_encoder(level, Check::None).unwrap();
+            let stream = stream::Stream::new_easy_encoder(level, stream::Check::None).unwrap();
             let mut encoder = XzEncoder::new_stream(TEST_DATA, stream);
             encoder.read_to_end(black_box(&mut compressed)).unwrap();
             liblzma_data.push(compressed);
@@ -191,7 +191,7 @@ fn bench_decompression_lzma2(c: &mut Criterion) {
             |b, (compressed, option)| {
                 b.iter(|| {
                     let mut uncompressed = Vec::new();
-                    let mut reader = LZMA2Reader::new(
+                    let mut reader = Lzma2Reader::new(
                         black_box(compressed.as_slice()),
                         option.lzma_options.dict_size,
                         None,
@@ -227,13 +227,13 @@ fn bench_compression_mt(c: &mut Criterion) {
     let num_workers = std::thread::available_parallelism().unwrap().get() as u32;
 
     group.bench_function(BenchmarkId::new("lzma2", 3), |b| {
-        let mut option = LZMA2Options::with_preset(3);
+        let mut option = Lzma2Options::with_preset(3);
         option.set_chunk_size(NonZeroU64::new(option.lzma_options.dict_size as u64));
 
         b.iter(|| {
             let mut compressed = Vec::new();
             let mut writer =
-                LZMA2WriterMT::new(black_box(&mut compressed), option.clone(), num_workers)
+                Lzma2WriterMt::new(black_box(&mut compressed), option.clone(), num_workers)
                     .unwrap();
             writer.write_all(black_box(TEST_DATA)).unwrap();
             writer.finish().unwrap();
@@ -242,13 +242,13 @@ fn bench_compression_mt(c: &mut Criterion) {
     });
 
     group.bench_function(BenchmarkId::new("lzip", 3), |b| {
-        let mut option = LZIPOptions::with_preset(3);
+        let mut option = LzipOptions::with_preset(3);
         option.set_member_size(NonZeroU64::new(option.lzma_options.dict_size as u64));
 
         b.iter(|| {
             let mut compressed = Vec::new();
             let mut writer =
-                LZIPWriterMT::new(black_box(&mut compressed), option.clone(), num_workers).unwrap();
+                LzipWriterMt::new(black_box(&mut compressed), option.clone(), num_workers).unwrap();
             writer.write_all(black_box(TEST_DATA)).unwrap();
             writer.finish().unwrap();
             black_box(compressed)
@@ -256,13 +256,13 @@ fn bench_compression_mt(c: &mut Criterion) {
     });
 
     group.bench_function(BenchmarkId::new("xz", 3), |b| {
-        let mut option = XZOptions::with_preset(3);
+        let mut option = XzOptions::with_preset(3);
         option.set_block_size(NonZeroU64::new(option.lzma_options.dict_size as u64));
 
         b.iter(|| {
             let mut compressed = Vec::new();
             let mut writer =
-                XZWriterMT::new(black_box(&mut compressed), option.clone(), num_workers).unwrap();
+                XzWriterMt::new(black_box(&mut compressed), option.clone(), num_workers).unwrap();
             writer.write_all(black_box(TEST_DATA)).unwrap();
             writer.finish().unwrap();
             black_box(compressed)
@@ -279,31 +279,31 @@ fn bench_decompression_mt(c: &mut Criterion) {
 
     let num_workers = std::thread::available_parallelism().unwrap().get() as u32;
 
-    let mut lzma2_option = LZMA2Options::with_preset(3);
+    let mut lzma2_option = Lzma2Options::with_preset(3);
     lzma2_option.set_chunk_size(NonZeroU64::new(lzma2_option.lzma_options.dict_size as u64));
     let mut lzma2_data = Vec::new();
-    let mut writer = LZMA2Writer::new(&mut lzma2_data, lzma2_option.clone());
+    let mut writer = Lzma2Writer::new(&mut lzma2_data, lzma2_option.clone());
     writer.write_all(TEST_DATA).unwrap();
     writer.finish().unwrap();
 
-    let mut lzip_option = LZIPOptions::with_preset(3);
+    let mut lzip_option = LzipOptions::with_preset(3);
     lzip_option.set_member_size(NonZeroU64::new(lzip_option.lzma_options.dict_size as u64));
     let mut lzip_data = Vec::new();
-    let mut writer = LZIPWriter::new(&mut lzip_data, lzip_option.clone());
+    let mut writer = LzipWriter::new(&mut lzip_data, lzip_option.clone());
     writer.write_all(TEST_DATA).unwrap();
     writer.finish().unwrap();
 
-    let mut xz_option = XZOptions::with_preset(3);
+    let mut xz_option = XzOptions::with_preset(3);
     xz_option.set_block_size(NonZeroU64::new(xz_option.lzma_options.dict_size as u64));
     let mut xz_data = Vec::new();
-    let mut writer = XZWriter::new(&mut xz_data, xz_option.clone()).unwrap();
+    let mut writer = XzWriter::new(&mut xz_data, xz_option.clone()).unwrap();
     writer.write_all(TEST_DATA).unwrap();
     writer.finish().unwrap();
 
     group.bench_function(BenchmarkId::new("lzma2", 3), |b| {
         b.iter(|| {
             let mut uncompressed = Vec::new();
-            let mut reader = LZMA2ReaderMT::new(
+            let mut reader = Lzma2ReaderMt::new(
                 black_box(lzma2_data.as_slice()),
                 lzma2_option.lzma_options.dict_size,
                 None,
@@ -318,7 +318,7 @@ fn bench_decompression_mt(c: &mut Criterion) {
         b.iter(|| {
             let mut uncompressed = Vec::new();
             let mut reader =
-                LZIPReaderMT::new(black_box(Cursor::new(lzip_data.as_slice())), num_workers)
+                LzipReaderMt::new(black_box(Cursor::new(lzip_data.as_slice())), num_workers)
                     .unwrap();
             reader.read_to_end(black_box(&mut uncompressed)).unwrap();
             black_box(uncompressed)
@@ -328,7 +328,7 @@ fn bench_decompression_mt(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("xz", 3), |b| {
         b.iter(|| {
             let mut uncompressed = Vec::new();
-            let mut reader = XZReaderMT::new(
+            let mut reader = XzReaderMt::new(
                 black_box(Cursor::new(xz_data.as_slice())),
                 false,
                 num_workers,

--- a/src/enc/encoder.rs
+++ b/src/enc/encoder.rs
@@ -3,7 +3,7 @@ use alloc::{vec, vec::Vec};
 use super::{
     encoder_fast::FastEncoderMode,
     encoder_normal::NormalEncoderMode,
-    lz::{LZEncoder, MFType},
+    lz::{LZEncoder, MfType},
     range_enc::{RangeEncoder, RangeEncoderBuffer},
 };
 use crate::{
@@ -115,7 +115,7 @@ impl LZMAEncoder {
         mode: EncodeMode,
         dict_size: u32,
         extra_size_before: u32,
-        mf: MFType,
+        mf: MfType,
     ) -> u32 {
         let mut m = 80;
         match mode {
@@ -137,7 +137,7 @@ impl LZMAEncoder {
         lc: u32,
         lp: u32,
         pb: u32,
-        mf: MFType,
+        mf: MfType,
         depth_limit: i32,
         dict_size: u32,
         nice_len: usize,
@@ -160,7 +160,7 @@ impl LZMAEncoder {
             )
         };
         let lz = match mf {
-            MFType::HC4 => LZEncoder::new_hc4(
+            MfType::Hc4 => LZEncoder::new_hc4(
                 dict_size,
                 extra_size_before,
                 extra_size_after,
@@ -168,7 +168,7 @@ impl LZMAEncoder {
                 MATCH_LEN_MAX as _,
                 depth_limit,
             ),
-            MFType::BT4 => LZEncoder::new_bt4(
+            MfType::Bt4 => LZEncoder::new_bt4(
                 dict_size,
                 extra_size_before,
                 extra_size_after,

--- a/src/enc/encoder_fast.rs
+++ b/src/enc/encoder_fast.rs
@@ -1,6 +1,6 @@
 use super::{
     encoder::LZMAEncoderTrait,
-    lz::{LZEncoder, MFType},
+    lz::{LZEncoder, MfType},
     MATCH_LEN_MAX, MATCH_LEN_MIN, REPS,
 };
 
@@ -11,7 +11,7 @@ impl FastEncoderMode {
     pub(crate) const EXTRA_SIZE_BEFORE: u32 = 1;
     pub(crate) const EXTRA_SIZE_AFTER: u32 = MATCH_LEN_MAX as u32 - 1;
 
-    pub(crate) fn get_memory_usage(dict_size: u32, extra_size_before: u32, mf: MFType) -> u32 {
+    pub(crate) fn get_memory_usage(dict_size: u32, extra_size_before: u32, mf: MfType) -> u32 {
         LZEncoder::get_memory_usage(
             dict_size,
             extra_size_before.max(Self::EXTRA_SIZE_BEFORE),

--- a/src/enc/encoder_normal.rs
+++ b/src/enc/encoder_normal.rs
@@ -2,7 +2,7 @@ use alloc::{vec, vec::Vec};
 
 use super::{
     encoder::{LZMAEncoder, LZMAEncoderTrait},
-    lz::{LZEncoder, MFType},
+    lz::{LZEncoder, MfType},
     state::State,
     MATCH_LEN_MAX, MATCH_LEN_MIN, REPS,
 };
@@ -20,7 +20,7 @@ impl NormalEncoderMode {
 
     pub(crate) const EXTRA_SIZE_AFTER: u32 = Self::OPTS;
 
-    pub(crate) fn get_memory_usage(dict_size: u32, extra_size_before: u32, mf: MFType) -> u32 {
+    pub(crate) fn get_memory_usage(dict_size: u32, extra_size_before: u32, mf: MfType) -> u32 {
         LZEncoder::get_memory_usage(
             dict_size,
             extra_size_before.max(Self::EXTRA_SIZE_BEFORE),

--- a/src/enc/lzma2_writer.rs
+++ b/src/enc/lzma2_writer.rs
@@ -3,14 +3,14 @@ use core::num::NonZeroU64;
 
 use super::{
     encoder::{EncodeMode, LZMAEncoder, LZMAEncoderModes},
-    lz::MFType,
+    lz::MfType,
     range_enc::{RangeEncoder, RangeEncoderBuffer},
 };
 use crate::{ByteWriter, Write};
 
 /// Encoder settings when compressing with LZMA and LZMA2.
 #[derive(Debug, Clone)]
-pub struct LZMAOptions {
+pub struct LzmaOptions {
     /// Dictionary size in bytes.
     pub dict_size: u32,
     /// Number of literal context bits (0-8).
@@ -24,20 +24,20 @@ pub struct LZMAOptions {
     /// Match finder nice length.
     pub nice_len: u32,
     /// Match finder type.
-    pub mf: MFType,
+    pub mf: MfType,
     /// Match finder depth limit.
     pub depth_limit: i32,
     /// Preset dictionary data.
     pub preset_dict: Option<Vec<u8>>,
 }
 
-impl Default for LZMAOptions {
+impl Default for LzmaOptions {
     fn default() -> Self {
         Self::with_preset(6)
     }
 }
 
-impl LZMAOptions {
+impl LzmaOptions {
     /// Default number of literal context bits.
     pub const LC_DEFAULT: u32 = 3;
 
@@ -80,7 +80,7 @@ impl LZMAOptions {
         pb: u32,
         mode: EncodeMode,
         nice_len: u32,
-        mf: MFType,
+        mf: MfType,
         depth_limit: i32,
     ) -> Self {
         Self {
@@ -124,12 +124,12 @@ impl LZMAOptions {
         self.dict_size = Self::PRESET_TO_DICT_SIZE[preset as usize];
         if preset <= 3 {
             self.mode = EncodeMode::Fast;
-            self.mf = MFType::HC4;
+            self.mf = MfType::Hc4;
             self.nice_len = if preset <= 1 { 128 } else { Self::NICE_LEN_MAX };
             self.depth_limit = Self::PRESET_TO_DEPTH_LIMIT[preset as usize];
         } else {
             self.mode = EncodeMode::Normal;
-            self.mf = MFType::BT4;
+            self.mf = MfType::Bt4;
             self.nice_len = if preset == 4 {
                 16
             } else if preset == 5 {
@@ -157,20 +157,20 @@ impl LZMAOptions {
 
 /// Options for LZMA2 compression.
 #[derive(Default, Debug, Clone)]
-pub struct LZMA2Options {
+pub struct Lzma2Options {
     /// LZMA compression options.
-    pub lzma_options: LZMAOptions,
+    pub lzma_options: LzmaOptions,
     /// The size of each independent chunk in bytes.
     /// If not set, the whole data will be written as one chunk.
     /// Will get clamped to be at least the dict size to not waste memory.
     pub chunk_size: Option<NonZeroU64>,
 }
 
-impl LZMA2Options {
+impl Lzma2Options {
     /// Create options with specific preset.
     pub fn with_preset(preset: u32) -> Self {
         Self {
-            lzma_options: LZMAOptions::with_preset(preset),
+            lzma_options: LzmaOptions::with_preset(preset),
             chunk_size: None,
         }
     }
@@ -190,7 +190,7 @@ pub fn get_extra_size_before(dict_size: u32) -> u32 {
 }
 
 /// A single-threaded LZMA2 compressor.
-pub struct LZMA2Writer<W: Write> {
+pub struct Lzma2Writer<W: Write> {
     inner: W,
     rc: RangeEncoder<RangeEncoderBuffer>,
     lzma: LZMAEncoder,
@@ -202,12 +202,12 @@ pub struct LZMA2Writer<W: Write> {
     chunk_size: Option<u64>,
     uncompressed_size: u64,
     force_independent_chunk: bool,
-    options: LZMA2Options,
+    options: Lzma2Options,
 }
 
-impl<W: Write> LZMA2Writer<W> {
+impl<W: Write> Lzma2Writer<W> {
     /// Creates a new LZMA2 writer that will write compressed data to the given writer.
-    pub fn new(inner: W, options: LZMA2Options) -> Self {
+    pub fn new(inner: W, options: Lzma2Options) -> Self {
         let lzma_options = &options.lzma_options;
         let dict_size = lzma_options.dict_size;
 
@@ -400,7 +400,7 @@ impl<W: Write> LZMA2Writer<W> {
     }
 }
 
-impl<W: Write> Write for LZMA2Writer<W> {
+impl<W: Write> Write for Lzma2Writer<W> {
     fn write(&mut self, buf: &[u8]) -> crate::Result<usize> {
         let mut len = buf.len();
 

--- a/src/enc/lzma_writer.rs
+++ b/src/enc/lzma_writer.rs
@@ -1,12 +1,12 @@
 use super::{
     encoder::{LZMAEncoder, LZMAEncoderModes},
     range_enc::RangeEncoder,
-    LZMAOptions,
+    LzmaOptions,
 };
 use crate::{error_invalid_input, error_unsupported, Write};
 
 /// A single-threaded LZMA compressor.
-pub struct LZMAWriter<W: Write> {
+pub struct LzmaWriter<W: Write> {
     rc: RangeEncoder<W>,
     lzma: LZMAEncoder,
     use_end_marker: bool,
@@ -16,15 +16,15 @@ pub struct LZMAWriter<W: Write> {
     mode: LZMAEncoderModes,
 }
 
-impl<W: Write> LZMAWriter<W> {
+impl<W: Write> LzmaWriter<W> {
     /// Creates a new LZMA writer with full control over formatting options.
     pub fn new(
         mut out: W,
-        options: &LZMAOptions,
+        options: &LzmaOptions,
         use_header: bool,
         use_end_marker: bool,
         expected_uncompressed_size: Option<u64>,
-    ) -> crate::Result<LZMAWriter<W>> {
+    ) -> crate::Result<LzmaWriter<W>> {
         let (mut lzma, mode) = LZMAEncoder::new(
             options.mode,
             options.lc,
@@ -54,7 +54,7 @@ impl<W: Write> LZMAWriter<W> {
         }
 
         let rc = RangeEncoder::new(out);
-        Ok(LZMAWriter {
+        Ok(LzmaWriter {
             rc,
             lzma,
             use_end_marker,
@@ -69,7 +69,7 @@ impl<W: Write> LZMAWriter<W> {
     #[inline]
     pub fn new_use_header(
         out: W,
-        options: &LZMAOptions,
+        options: &LzmaOptions,
         input_size: Option<u64>,
     ) -> crate::Result<Self> {
         Self::new(out, options, true, input_size.is_none(), input_size)
@@ -79,7 +79,7 @@ impl<W: Write> LZMAWriter<W> {
     #[inline]
     pub fn new_no_header(
         out: W,
-        options: &LZMAOptions,
+        options: &LzmaOptions,
         use_end_marker: bool,
     ) -> crate::Result<Self> {
         Self::new(out, options, false, use_end_marker, None)
@@ -134,7 +134,7 @@ impl<W: Write> LZMAWriter<W> {
     }
 }
 
-impl<W: Write> Write for LZMAWriter<W> {
+impl<W: Write> Write for LzmaWriter<W> {
     fn write(&mut self, buf: &[u8]) -> crate::Result<usize> {
         if let Some(exp) = self.expected_uncompressed_size {
             if exp < self.current_uncompressed_size + buf.len() as u64 {

--- a/src/filter/bcj.rs
+++ b/src/filter/bcj.rs
@@ -33,7 +33,7 @@ impl BCJFilter {
 const FILTER_BUF_SIZE: usize = 4096;
 
 /// Reader that applies BCJ (Branch/Call/Jump) filtering to compressed data.
-pub struct BCJReader<R> {
+pub struct BcjReader<R> {
     inner: R,
     filter: BCJFilter,
     state: State,
@@ -49,7 +49,7 @@ struct State {
     end_reached: bool,
 }
 
-impl<R> BCJReader<R> {
+impl<R> BcjReader<R> {
     fn new(inner: R, filter: BCJFilter) -> Self {
         Self {
             inner,
@@ -126,7 +126,7 @@ impl<R> BCJReader<R> {
     }
 }
 
-impl<R: Read> Read for BCJReader<R> {
+impl<R: Read> Read for BcjReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
@@ -203,14 +203,14 @@ impl<R: Read> Read for BCJReader<R> {
 
 /// Writer that applies BCJ (Branch/Call/Jump) filtering to data before compression.
 #[cfg(feature = "encoder")]
-pub struct BCJWriter<W> {
+pub struct BcjWriter<W> {
     inner: W,
     filter: BCJFilter,
     buffer: Vec<u8>,
 }
 
 #[cfg(feature = "encoder")]
-impl<W> BCJWriter<W> {
+impl<W> BcjWriter<W> {
     fn new(inner: W, filter: BCJFilter) -> Self {
         Self {
             inner,
@@ -299,7 +299,7 @@ impl<W> BCJWriter<W> {
 }
 
 #[cfg(feature = "encoder")]
-impl<W: Write> Write for BCJWriter<W> {
+impl<W: Write> Write for BcjWriter<W> {
     fn write(&mut self, buf: &[u8]) -> crate::Result<usize> {
         let original_len = buf.len();
 
@@ -338,14 +338,14 @@ mod tests {
         let test_data = std::fs::read("tests/data/wget-x86").unwrap();
 
         let mut encoded_buffer = Vec::new();
-        let mut writer = BCJWriter::new_x86(Cursor::new(&mut encoded_buffer), 0);
+        let mut writer = BcjWriter::new_x86(Cursor::new(&mut encoded_buffer), 0);
         copy(&mut test_data.as_slice(), &mut writer).expect("Failed to encode data");
         writer.finish().expect("Failed to finish encoding");
 
         assert!(test_data != encoded_buffer);
 
         let mut decoded_data = Vec::new();
-        let mut reader = BCJReader::new_x86(Cursor::new(&encoded_buffer), 0);
+        let mut reader = BcjReader::new_x86(Cursor::new(&encoded_buffer), 0);
         copy(&mut reader, &mut decoded_data).expect("Failed to decode data");
 
         assert!(test_data == decoded_data);
@@ -356,14 +356,14 @@ mod tests {
         let test_data = std::fs::read("tests/data/wget-arm").unwrap();
 
         let mut encoded_buffer = Vec::new();
-        let mut writer = BCJWriter::new_arm(Cursor::new(&mut encoded_buffer), 0);
+        let mut writer = BcjWriter::new_arm(Cursor::new(&mut encoded_buffer), 0);
         copy(&mut test_data.as_slice(), &mut writer).expect("Failed to encode data");
         writer.finish().expect("Failed to finish encoding");
 
         assert!(test_data != encoded_buffer);
 
         let mut decoded_data = Vec::new();
-        let mut reader = BCJReader::new_arm(Cursor::new(&encoded_buffer), 0);
+        let mut reader = BcjReader::new_arm(Cursor::new(&encoded_buffer), 0);
         copy(&mut reader, &mut decoded_data).expect("Failed to decode data");
 
         assert!(test_data == decoded_data);
@@ -374,14 +374,14 @@ mod tests {
         let test_data = std::fs::read("tests/data/wget-arm64").unwrap();
 
         let mut encoded_buffer = Vec::new();
-        let mut writer = BCJWriter::new_arm64(Cursor::new(&mut encoded_buffer), 0);
+        let mut writer = BcjWriter::new_arm64(Cursor::new(&mut encoded_buffer), 0);
         copy(&mut test_data.as_slice(), &mut writer).expect("Failed to encode data");
         writer.finish().expect("Failed to finish encoding");
 
         assert!(test_data != encoded_buffer);
 
         let mut decoded_data = Vec::new();
-        let mut reader = BCJReader::new_arm64(Cursor::new(&encoded_buffer), 0);
+        let mut reader = BcjReader::new_arm64(Cursor::new(&encoded_buffer), 0);
         copy(&mut reader, &mut decoded_data).expect("Failed to decode data");
 
         assert!(test_data == decoded_data);
@@ -392,14 +392,14 @@ mod tests {
         let test_data = std::fs::read("tests/data/wget-arm-thumb").unwrap();
 
         let mut encoded_buffer = Vec::new();
-        let mut writer = BCJWriter::new_arm_thumb(Cursor::new(&mut encoded_buffer), 0);
+        let mut writer = BcjWriter::new_arm_thumb(Cursor::new(&mut encoded_buffer), 0);
         copy(&mut test_data.as_slice(), &mut writer).expect("Failed to encode data");
         writer.finish().expect("Failed to finish encoding");
 
         assert!(test_data != encoded_buffer);
 
         let mut decoded_data = Vec::new();
-        let mut reader = BCJReader::new_arm_thumb(Cursor::new(&encoded_buffer), 0);
+        let mut reader = BcjReader::new_arm_thumb(Cursor::new(&encoded_buffer), 0);
         copy(&mut reader, &mut decoded_data).expect("Failed to decode data");
 
         assert!(test_data == decoded_data);
@@ -410,14 +410,14 @@ mod tests {
         let test_data = std::fs::read("tests/data/wget-ppc").unwrap();
 
         let mut encoded_buffer = Vec::new();
-        let mut writer = BCJWriter::new_ppc(Cursor::new(&mut encoded_buffer), 0);
+        let mut writer = BcjWriter::new_ppc(Cursor::new(&mut encoded_buffer), 0);
         copy(&mut test_data.as_slice(), &mut writer).expect("Failed to encode data");
         writer.finish().expect("Failed to finish encoding");
 
         assert!(test_data != encoded_buffer);
 
         let mut decoded_data = Vec::new();
-        let mut reader = BCJReader::new_ppc(Cursor::new(&encoded_buffer), 0);
+        let mut reader = BcjReader::new_ppc(Cursor::new(&encoded_buffer), 0);
         copy(&mut reader, &mut decoded_data).expect("Failed to decode data");
 
         assert!(test_data == decoded_data);
@@ -428,14 +428,14 @@ mod tests {
         let test_data = std::fs::read("tests/data/wget-sparc").unwrap();
 
         let mut encoded_buffer = Vec::new();
-        let mut writer = BCJWriter::new_sparc(Cursor::new(&mut encoded_buffer), 0);
+        let mut writer = BcjWriter::new_sparc(Cursor::new(&mut encoded_buffer), 0);
         copy(&mut test_data.as_slice(), &mut writer).expect("Failed to encode data");
         writer.finish().expect("Failed to finish encoding");
 
         assert!(test_data != encoded_buffer);
 
         let mut decoded_data = Vec::new();
-        let mut reader = BCJReader::new_sparc(Cursor::new(&encoded_buffer), 0);
+        let mut reader = BcjReader::new_sparc(Cursor::new(&encoded_buffer), 0);
         copy(&mut reader, &mut decoded_data).expect("Failed to decode data");
 
         assert!(test_data == decoded_data);
@@ -446,14 +446,14 @@ mod tests {
         let test_data = std::fs::read("tests/data/wget-ia64").unwrap();
 
         let mut encoded_buffer = Vec::new();
-        let mut writer = BCJWriter::new_ia64(Cursor::new(&mut encoded_buffer), 0);
+        let mut writer = BcjWriter::new_ia64(Cursor::new(&mut encoded_buffer), 0);
         copy(&mut test_data.as_slice(), &mut writer).expect("Failed to encode data");
         writer.finish().expect("Failed to finish encoding");
 
         assert!(test_data != encoded_buffer);
 
         let mut decoded_data = Vec::new();
-        let mut reader = BCJReader::new_ia64(Cursor::new(&encoded_buffer), 0);
+        let mut reader = BcjReader::new_ia64(Cursor::new(&encoded_buffer), 0);
         copy(&mut reader, &mut decoded_data).expect("Failed to decode data");
 
         assert!(test_data == decoded_data);
@@ -464,14 +464,14 @@ mod tests {
         let test_data = std::fs::read("tests/data/wget-riscv").unwrap();
 
         let mut encoded_buffer = Vec::new();
-        let mut writer = BCJWriter::new_riscv(Cursor::new(&mut encoded_buffer), 0);
+        let mut writer = BcjWriter::new_riscv(Cursor::new(&mut encoded_buffer), 0);
         copy(&mut test_data.as_slice(), &mut writer).expect("Failed to encode data");
         writer.finish().expect("Failed to finish encoding");
 
         assert!(test_data != encoded_buffer);
 
         let mut decoded_data = Vec::new();
-        let mut reader = BCJReader::new_riscv(Cursor::new(&encoded_buffer), 0);
+        let mut reader = BcjReader::new_riscv(Cursor::new(&encoded_buffer), 0);
         copy(&mut reader, &mut decoded_data).expect("Failed to decode data");
 
         assert!(test_data == decoded_data);

--- a/src/filter/bcj2.rs
+++ b/src/filter/bcj2.rs
@@ -63,7 +63,7 @@ impl Default for Bcj2Coder {
 }
 
 /// Reader for BCJ2-filtered data with multiple input streams.
-pub struct BCJ2Reader<R> {
+pub struct Bcj2Reader<R> {
     base: Bcj2Coder,
     inputs: Vec<R>,
     decoder: Bcj2Decoder,
@@ -72,7 +72,7 @@ pub struct BCJ2Reader<R> {
     uncompressed_size: u64,
 }
 
-impl<R> BCJ2Reader<R> {
+impl<R> Bcj2Reader<R> {
     /// Creates a new BCJ2 reader with the given input streams and expected output size.
     pub fn new(inputs: Vec<R>, uncompressed_size: u64) -> Self {
         Self {
@@ -98,7 +98,7 @@ impl<R> BCJ2Reader<R> {
     }
 }
 
-impl<R: Read> Read for BCJ2Reader<R> {
+impl<R: Read> Read for Bcj2Reader<R> {
     fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
         let mut dest_buf = buf;
         if dest_buf.len() > self.uncompressed_size as usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,21 +88,21 @@ pub(crate) use std::io::Write;
 
 #[cfg(feature = "encoder")]
 pub use enc::*;
-pub use lz::MFType;
+pub use lz::MfType;
 #[cfg(feature = "lzip")]
-pub use lzip::LZIPReader;
+pub use lzip::LzipReader;
 #[cfg(all(feature = "lzip", feature = "std"))]
-pub use lzip::LZIPReaderMT;
+pub use lzip::LzipReaderMt;
 #[cfg(all(feature = "lzip", feature = "encoder"))]
-pub use lzip::{AutoFinishLZIPWriter, LZIPOptions, LZIPWriter};
+pub use lzip::{AutoFinishLzipWriter, LzipOptions, LzipWriter};
 #[cfg(all(feature = "lzip", feature = "encoder", feature = "std"))]
-pub use lzip::{AutoFinishLZIPWriterMT, LZIPWriterMT};
-pub use lzma2_reader::{get_memory_usage as lzma2_get_memory_usage, LZMA2Reader};
+pub use lzip::{AutoFinishLzipWriterMt, LzipWriterMt};
+pub use lzma2_reader::{get_memory_usage as lzma2_get_memory_usage, Lzma2Reader};
 #[cfg(feature = "std")]
-pub use lzma2_reader_mt::LZMA2ReaderMT;
+pub use lzma2_reader_mt::Lzma2ReaderMt;
 pub use lzma_reader::{
     get_memory_usage as lzma_get_memory_usage,
-    get_memory_usage_by_props as lzma_get_memory_usage_by_props, LZMAReader,
+    get_memory_usage_by_props as lzma_get_memory_usage_by_props, LzmaReader,
 };
 #[cfg(not(feature = "std"))]
 pub use no_std::Error;
@@ -112,13 +112,13 @@ pub use no_std::Read;
 pub use no_std::Write;
 use state::*;
 #[cfg(all(feature = "xz", feature = "std"))]
-pub use xz::XZReaderMT;
+pub use xz::XzReaderMt;
 #[cfg(all(feature = "xz", feature = "encoder"))]
-pub use xz::{AutoFinishXZWriter, XZOptions, XZWriter};
+pub use xz::{AutoFinishXzWriter, XzOptions, XzWriter};
 #[cfg(all(feature = "xz", feature = "encoder", feature = "std"))]
-pub use xz::{AutoFinishXZWriterMT, XZWriterMT};
+pub use xz::{AutoFinishXzWriterMt, XzWriterMt};
 #[cfg(feature = "xz")]
-pub use xz::{CheckType, XZReader};
+pub use xz::{CheckType, XzReader};
 
 /// Result type of the crate.
 #[cfg(feature = "std")]

--- a/src/lz/bt4.rs
+++ b/src/lz/bt4.rs
@@ -3,7 +3,7 @@ use alloc::{vec, vec::Vec};
 use super::{extend_match, hash234::Hash234, LZEncoder, MatchFind, Matches};
 
 /// Binary Tree with 4-byte matching
-pub(crate) struct BT4 {
+pub(crate) struct Bt4 {
     hash: Hash234,
     tree: Vec<i32>,
     depth_limit: i32,
@@ -19,7 +19,7 @@ fn sh_left(i: i32) -> i32 {
     ((i as u32) << 1) as i32
 }
 
-impl BT4 {
+impl Bt4 {
     pub(crate) fn new(dict_size: u32, nice_len: u32, depth_limit: i32) -> Self {
         let cyclic_size = dict_size as i32 + 1;
 
@@ -123,7 +123,7 @@ impl BT4 {
     }
 }
 
-impl MatchFind for BT4 {
+impl MatchFind for Bt4 {
     fn find_matches(&mut self, encoder: &mut super::LZEncoderData, matches: &mut Matches) {
         matches.count = 0;
 

--- a/src/lz/hc4.rs
+++ b/src/lz/hc4.rs
@@ -8,7 +8,7 @@ use super::{
 };
 
 /// Hash Chain with 4-byte matching
-pub(crate) struct HC4 {
+pub(crate) struct Hc4 {
     hash: Hash234,
     chain: Vec<i32>,
     depth_limit: i32,
@@ -17,7 +17,7 @@ pub(crate) struct HC4 {
     lz_pos: i32,
 }
 
-impl HC4 {
+impl Hc4 {
     pub(crate) fn get_mem_usage(dict_size: u32) -> u32 {
         Hash234::get_mem_usage(dict_size) + dict_size / (1024 / 4) + 10
     }
@@ -60,7 +60,7 @@ impl HC4 {
     }
 }
 
-impl MatchFind for HC4 {
+impl MatchFind for Hc4 {
     fn find_matches(&mut self, encoder: &mut LZEncoderData, matches: &mut Matches) {
         matches.count = 0;
         let mut match_len_limit = encoder.match_len_max as i32;

--- a/src/lz/lz_encoder.rs
+++ b/src/lz/lz_encoder.rs
@@ -1,7 +1,7 @@
 use alloc::{vec, vec::Vec};
 use core::ops::Deref;
 
-use super::{bt4::BT4, extend_match, hc4::HC4};
+use super::{bt4::Bt4, extend_match, hc4::Hc4};
 use crate::Write;
 
 /// Align to a 64-byte cache line
@@ -14,47 +14,47 @@ pub(crate) trait MatchFind {
 }
 
 pub(crate) enum MatchFinders {
-    HC4(HC4),
-    BT4(BT4),
+    Hc4(Hc4),
+    Bt4(Bt4),
 }
 
 impl MatchFind for MatchFinders {
     fn find_matches(&mut self, encoder: &mut LZEncoderData, matches: &mut Matches) {
         match self {
-            MatchFinders::HC4(m) => m.find_matches(encoder, matches),
-            MatchFinders::BT4(m) => m.find_matches(encoder, matches),
+            MatchFinders::Hc4(m) => m.find_matches(encoder, matches),
+            MatchFinders::Bt4(m) => m.find_matches(encoder, matches),
         }
     }
 
     fn skip(&mut self, encoder: &mut LZEncoderData, len: usize) {
         match self {
-            MatchFinders::HC4(m) => m.skip(encoder, len),
-            MatchFinders::BT4(m) => m.skip(encoder, len),
+            MatchFinders::Hc4(m) => m.skip(encoder, len),
+            MatchFinders::Bt4(m) => m.skip(encoder, len),
         }
     }
 }
 
 /// Match finders to use when encoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MFType {
+pub enum MfType {
     /// Hash chain for 4 bytes entries (lower quality but faster).
-    HC4,
+    Hc4,
     /// Binary tree for 4 byte entries (higher quality but slower).
-    BT4,
+    Bt4,
 }
 
-impl Default for MFType {
+impl Default for MfType {
     fn default() -> Self {
-        Self::HC4
+        Self::Hc4
     }
 }
 
-impl MFType {
+impl MfType {
     #[inline]
     fn get_memory_usage(self, dict_size: u32) -> u32 {
         match self {
-            MFType::HC4 => HC4::get_mem_usage(dict_size),
-            MFType::BT4 => BT4::get_mem_usage(dict_size),
+            MfType::Hc4 => Hc4::get_mem_usage(dict_size),
+            MfType::Bt4 => Bt4::get_mem_usage(dict_size),
         }
     }
 }
@@ -102,7 +102,7 @@ impl LZEncoder {
         extra_size_before: u32,
         extra_size_after: u32,
         match_len_max: u32,
-        mf: MFType,
+        mf: MfType,
     ) -> u32 {
         get_buf_size(
             dict_size,
@@ -126,7 +126,7 @@ impl LZEncoder {
             extra_size_after,
             nice_len,
             match_len_max,
-            MatchFinders::HC4(HC4::new(dict_size, nice_len, depth_limit)),
+            MatchFinders::Hc4(Hc4::new(dict_size, nice_len, depth_limit)),
         )
     }
 
@@ -144,7 +144,7 @@ impl LZEncoder {
             extra_size_after,
             nice_len,
             match_len_max,
-            MatchFinders::BT4(BT4::new(dict_size, nice_len, depth_limit)),
+            MatchFinders::Bt4(Bt4::new(dict_size, nice_len, depth_limit)),
         )
     }
 

--- a/src/lzip.rs
+++ b/src/lzip.rs
@@ -14,13 +14,13 @@ mod writer_mt;
 #[cfg(feature = "std")]
 use std::io::{Seek, SeekFrom};
 
-pub use reader::LZIPReader;
+pub use reader::LzipReader;
 #[cfg(feature = "std")]
-pub use reader_mt::LZIPReaderMT;
+pub use reader_mt::LzipReaderMt;
 #[cfg(feature = "encoder")]
-pub use writer::{AutoFinishLZIPWriter, LZIPOptions, LZIPWriter};
+pub use writer::{AutoFinishLzipWriter, LzipOptions, LzipWriter};
 #[cfg(all(feature = "encoder", feature = "std"))]
-pub use writer_mt::{AutoFinishLZIPWriterMT, LZIPWriterMT};
+pub use writer_mt::{AutoFinishLzipWriterMt, LzipWriterMt};
 
 use crate::{error_invalid_data, error_invalid_input, ByteReader, Read, Result};
 

--- a/src/lzip/reader.rs
+++ b/src/lzip/reader.rs
@@ -1,12 +1,12 @@
 use alloc::vec::Vec;
 
 use super::{LZIPHeader, LZIPTrailer, CRC32, HEADER_SIZE, TRAILER_SIZE};
-use crate::{error_invalid_data, error_invalid_input, CountingReader, LZMAReader, Read, Result};
+use crate::{error_invalid_data, error_invalid_input, CountingReader, LzmaReader, Read, Result};
 
 /// A single-threaded LZIP decompressor.
-pub struct LZIPReader<R> {
+pub struct LzipReader<R> {
     inner: Option<R>,
-    lzma_reader: Option<LZMAReader<CountingReader<R>>>,
+    lzma_reader: Option<LzmaReader<CountingReader<R>>>,
     current_header: Option<LZIPHeader>,
     finished: bool,
     trailer_buf: Vec<u8>,
@@ -14,8 +14,8 @@ pub struct LZIPReader<R> {
     data_size: u64,
 }
 
-impl<R> LZIPReader<R> {
-    /// Consume the LZIPReader and return the inner reader.
+impl<R> LzipReader<R> {
+    /// Consume the LzipReader and return the inner reader.
     pub fn into_inner(mut self) -> R {
         if let Some(lzma_reader) = self.lzma_reader.take() {
             return lzma_reader.into_inner().inner;
@@ -41,7 +41,7 @@ impl<R> LZIPReader<R> {
     }
 }
 
-impl<R: Read> LZIPReader<R> {
+impl<R: Read> LzipReader<R> {
     /// Create a new LZIP reader.
     pub fn new(inner: R) -> Result<Self> {
         Ok(Self {
@@ -82,7 +82,7 @@ impl<R: Read> LZIPReader<R> {
         // - pb=2 (position bits)
         // - Unlimited uncompressed size (we'll use trailer to verify)
         let lzma_reader =
-            LZMAReader::new(counting_reader, u64::MAX, 3, 0, 2, header.dict_size, None)?;
+            LzmaReader::new(counting_reader, u64::MAX, 3, 0, 2, header.dict_size, None)?;
 
         self.current_header = Some(header);
         self.lzma_reader = Some(lzma_reader);
@@ -127,7 +127,7 @@ impl<R: Read> LZIPReader<R> {
     }
 }
 
-impl<R: Read> Read for LZIPReader<R> {
+impl<R: Read> Read for LzipReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         if buf.is_empty() {
             return Ok(0);

--- a/src/lzip/reader_mt.rs
+++ b/src/lzip/reader_mt.rs
@@ -12,7 +12,7 @@ use crate::{
     set_error,
     work_pool::{WorkPool, WorkPoolConfig, WorkPoolState},
     work_queue::WorkerHandle,
-    LZIPReader, Read,
+    LzipReader, Read,
 };
 
 /// A work unit for a worker thread.
@@ -22,14 +22,14 @@ struct WorkUnit {
 }
 
 /// A multi-threaded LZIP decompressor.
-pub struct LZIPReaderMT<R: Read + Seek> {
+pub struct LzipReaderMt<R: Read + Seek> {
     inner: R,
     members: Vec<LZIPMember>,
     work_pool: WorkPool<WorkUnit, Vec<u8>>,
     current_chunk: Cursor<Vec<u8>>,
 }
 
-impl<R: Read + Seek> LZIPReaderMT<R> {
+impl<R: Read + Seek> LzipReaderMt<R> {
     /// Creates a new multi-threaded LZIP reader.
     ///
     /// - `inner`: The reader to read compressed data from. Must implement Seek.
@@ -92,7 +92,7 @@ fn worker_thread_logic(
 
         let (index, WorkUnit { member_data }) = work_unit;
 
-        let reader_result = LZIPReader::new(member_data.as_slice());
+        let reader_result = LzipReader::new(member_data.as_slice());
 
         let mut lzip_reader = match reader_result {
             Ok(reader) => reader,
@@ -122,7 +122,7 @@ fn worker_thread_logic(
     }
 }
 
-impl<R: Read + Seek> Read for LZIPReaderMT<R> {
+impl<R: Read + Seek> Read for LzipReaderMt<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -16,17 +16,17 @@ pub const COMPRESSED_SIZE_MAX: u32 = 1 << 16;
 /// ```
 /// use std::io::Read;
 ///
-/// use lzma_rust2::{LZMA2Reader, LZMAOptions};
+/// use lzma_rust2::{Lzma2Reader, LzmaOptions};
 ///
 /// let compressed: Vec<u8> = vec![
 ///     1, 0, 12, 72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33, 0,
 /// ];
-/// let mut reader = LZMA2Reader::new(compressed.as_slice(), LZMAOptions::DICT_SIZE_DEFAULT, None);
+/// let mut reader = Lzma2Reader::new(compressed.as_slice(), LzmaOptions::DICT_SIZE_DEFAULT, None);
 /// let mut decompressed = Vec::new();
 /// reader.read_to_end(&mut decompressed).unwrap();
 /// assert_eq!(&decompressed[..], b"Hello, world!");
 /// ```
-pub struct LZMA2Reader<R> {
+pub struct Lzma2Reader<R> {
     inner: R,
     lz: LZDecoder,
     rc: RangeDecoder<RangeDecoderBuffer>,
@@ -50,7 +50,7 @@ fn get_dict_size(dict_size: u32) -> u32 {
     (dict_size + 15) & !15
 }
 
-impl<R> LZMA2Reader<R> {
+impl<R> Lzma2Reader<R> {
     /// Unwraps the reader, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.inner
@@ -67,7 +67,7 @@ impl<R> LZMA2Reader<R> {
     }
 }
 
-impl<R: Read> LZMA2Reader<R> {
+impl<R: Read> Lzma2Reader<R> {
     /// Create a new LZMA2 reader.
     /// `inner` is the reader to read compressed data from.
     /// `dict_size` is the dictionary size in bytes.
@@ -218,7 +218,7 @@ impl<R: Read> LZMA2Reader<R> {
     }
 }
 
-impl<R: Read> Read for LZMA2Reader<R> {
+impl<R: Read> Read for Lzma2Reader<R> {
     fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
         match self.read_decode(buf) {
             Ok(size) => Ok(size),

--- a/src/lzma2_reader_mt.rs
+++ b/src/lzma2_reader_mt.rs
@@ -13,7 +13,7 @@ use std::{
 use crate::{
     set_error,
     work_queue::{WorkStealingQueue, WorkerHandle},
-    LZMA2Reader,
+    Lzma2Reader,
 };
 
 /// A work unit for a worker thread.
@@ -37,7 +37,7 @@ enum State {
 }
 
 /// A multi-threaded LZMA2 decompressor.
-pub struct LZMA2ReaderMT<R: Read> {
+pub struct Lzma2ReaderMt<R: Read> {
     inner: R,
     result_rx: Receiver<ResultUnit>,
     result_tx: SyncSender<ResultUnit>,
@@ -58,7 +58,7 @@ pub struct LZMA2ReaderMT<R: Read> {
     worker_handles: Vec<thread::JoinHandle<()>>,
 }
 
-impl<R: Read> LZMA2ReaderMT<R> {
+impl<R: Read> Lzma2ReaderMt<R> {
     /// Creates a new multi-threaded LZMA2 reader.
     ///
     /// - `inner`: The reader to read compressed data from.
@@ -377,7 +377,7 @@ fn worker_thread_logic(
             }
         };
 
-        let mut reader = LZMA2Reader::new(
+        let mut reader = Lzma2Reader::new(
             work_unit_data.as_slice(),
             dict_size,
             preset_dict.as_deref().map(|v| v.as_slice()),
@@ -402,7 +402,7 @@ fn worker_thread_logic(
     }
 }
 
-impl<R: Read> Read for LZMA2ReaderMT<R> {
+impl<R: Read> Read for Lzma2ReaderMt<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
@@ -428,7 +428,7 @@ impl<R: Read> Read for LZMA2ReaderMT<R> {
     }
 }
 
-impl<R: Read> Drop for LZMA2ReaderMT<R> {
+impl<R: Read> Drop for Lzma2ReaderMt<R> {
     fn drop(&mut self) {
         self.shutdown_flag.store(true, Ordering::Release);
         self.work_queue.close();

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -39,13 +39,13 @@ fn get_dict_size(dict_size: u32) -> crate::Result<u32> {
 /// ```
 /// use std::io::Read;
 ///
-/// use lzma_rust2::LZMAReader;
+/// use lzma_rust2::LzmaReader;
 ///
 /// let compressed: Vec<u8> = vec![
 ///     93, 0, 0, 128, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 36, 25, 73, 152, 111, 22, 2,
 ///     140, 232, 230, 91, 177, 71, 198, 206, 183, 99, 255, 255, 60, 172, 0, 0,
 /// ];
-/// let mut reader = LZMAReader::new_mem_limit(compressed.as_slice(), u32::MAX, None).unwrap();
+/// let mut reader = LzmaReader::new_mem_limit(compressed.as_slice(), u32::MAX, None).unwrap();
 /// let mut buf = [0; 1024];
 /// let mut out = Vec::new();
 /// loop {
@@ -57,7 +57,7 @@ fn get_dict_size(dict_size: u32) -> crate::Result<u32> {
 /// }
 /// assert_eq!(out, b"Hello, world!");
 /// ```
-pub struct LZMAReader<R> {
+pub struct LzmaReader<R> {
     lz: LZDecoder,
     rc: RangeDecoder<R>,
     lzma: LZMADecoder,
@@ -66,7 +66,7 @@ pub struct LZMAReader<R> {
     remaining_size: u64,
 }
 
-impl<R> LZMAReader<R> {
+impl<R> LzmaReader<R> {
     /// Unwraps the reader, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.rc.into_inner()
@@ -83,7 +83,7 @@ impl<R> LZMAReader<R> {
     }
 }
 
-impl<R: Read> LZMAReader<R> {
+impl<R: Read> LzmaReader<R> {
     fn construct1(
         reader: R,
         uncomp_size: u64,
@@ -257,7 +257,7 @@ impl<R: Read> LZMAReader<R> {
     }
 }
 
-impl<R: Read> Read for LZMAReader<R> {
+impl<R: Read> Read for LzmaReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
         self.read_decode(buf)
     }

--- a/src/xz.rs
+++ b/src/xz.rs
@@ -12,20 +12,20 @@ use alloc::{boxed::Box, vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::io::{self, Seek, SeekFrom};
 
-pub use reader::XZReader;
+pub use reader::XzReader;
 #[cfg(feature = "std")]
-pub use reader_mt::XZReaderMT;
+pub use reader_mt::XzReaderMt;
 use sha2::Digest;
 #[cfg(feature = "encoder")]
-pub use writer::{AutoFinishXZWriter, XZOptions, XZWriter};
+pub use writer::{AutoFinishXzWriter, XzOptions, XzWriter};
 #[cfg(all(feature = "encoder", feature = "std"))]
-pub use writer_mt::{AutoFinishXZWriterMT, XZWriterMT};
+pub use writer_mt::{AutoFinishXzWriterMt, XzWriterMt};
 
 use crate::{error_invalid_data, error_invalid_input, ByteReader, ByteWriter, Read, Write};
 #[cfg(feature = "std")]
 use crate::{
-    filter::{bcj::BCJReader, delta::DeltaReader},
-    LZMA2Reader,
+    filter::{bcj::BcjReader, delta::DeltaReader},
+    Lzma2Reader,
 };
 
 const CRC32: crc::Crc<u32, crc::Table<16>> =
@@ -1092,39 +1092,39 @@ fn create_filter_chain<'reader>(
             }
             FilterType::BcjX86 => {
                 let start_offset = property as usize;
-                Box::new(BCJReader::new_x86(chain_reader, start_offset))
+                Box::new(BcjReader::new_x86(chain_reader, start_offset))
             }
             FilterType::BcjPPC => {
                 let start_offset = property as usize;
-                Box::new(BCJReader::new_ppc(chain_reader, start_offset))
+                Box::new(BcjReader::new_ppc(chain_reader, start_offset))
             }
             FilterType::BcjIA64 => {
                 let start_offset = property as usize;
-                Box::new(BCJReader::new_ia64(chain_reader, start_offset))
+                Box::new(BcjReader::new_ia64(chain_reader, start_offset))
             }
             FilterType::BcjARM => {
                 let start_offset = property as usize;
-                Box::new(BCJReader::new_arm(chain_reader, start_offset))
+                Box::new(BcjReader::new_arm(chain_reader, start_offset))
             }
             FilterType::BcjARMThumb => {
                 let start_offset = property as usize;
-                Box::new(BCJReader::new_arm_thumb(chain_reader, start_offset))
+                Box::new(BcjReader::new_arm_thumb(chain_reader, start_offset))
             }
             FilterType::BcjSPARC => {
                 let start_offset = property as usize;
-                Box::new(BCJReader::new_sparc(chain_reader, start_offset))
+                Box::new(BcjReader::new_sparc(chain_reader, start_offset))
             }
             FilterType::BcjARM64 => {
                 let start_offset = property as usize;
-                Box::new(BCJReader::new_arm64(chain_reader, start_offset))
+                Box::new(BcjReader::new_arm64(chain_reader, start_offset))
             }
             FilterType::BcjRISCV => {
                 let start_offset = property as usize;
-                Box::new(BCJReader::new_riscv(chain_reader, start_offset))
+                Box::new(BcjReader::new_riscv(chain_reader, start_offset))
             }
             FilterType::LZMA2 => {
                 let dict_size = property;
-                Box::new(LZMA2Reader::new(chain_reader, dict_size, None))
+                Box::new(Lzma2Reader::new(chain_reader, dict_size, None))
             }
         };
     }

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -5,16 +5,16 @@ use super::{
 };
 use crate::{
     error_invalid_data,
-    filter::{bcj::BCJReader, delta::DeltaReader},
-    CountingReader, LZMA2Reader, Read, Result,
+    filter::{bcj::BcjReader, delta::DeltaReader},
+    CountingReader, Lzma2Reader, Read, Result,
 };
 
 #[allow(clippy::large_enum_variant)]
 enum FilterReader<R: Read> {
     Counting(CountingReader<R>),
-    LZMA2(LZMA2Reader<Box<FilterReader<R>>>),
+    LZMA2(Lzma2Reader<Box<FilterReader<R>>>),
     Delta(DeltaReader<Box<FilterReader<R>>>),
-    Bcj(BCJReader<Box<FilterReader<R>>>),
+    Bcj(BcjReader<Box<FilterReader<R>>>),
     Dummy,
 }
 
@@ -48,42 +48,42 @@ impl<R: Read> FilterReader<R> {
                 }
                 FilterType::BcjX86 => {
                     let start_offset = property as usize;
-                    FilterReader::Bcj(BCJReader::new_x86(Box::new(chain_reader), start_offset))
+                    FilterReader::Bcj(BcjReader::new_x86(Box::new(chain_reader), start_offset))
                 }
                 FilterType::BcjPPC => {
                     let start_offset = property as usize;
-                    FilterReader::Bcj(BCJReader::new_ppc(Box::new(chain_reader), start_offset))
+                    FilterReader::Bcj(BcjReader::new_ppc(Box::new(chain_reader), start_offset))
                 }
                 FilterType::BcjIA64 => {
                     let start_offset = property as usize;
-                    FilterReader::Bcj(BCJReader::new_ia64(Box::new(chain_reader), start_offset))
+                    FilterReader::Bcj(BcjReader::new_ia64(Box::new(chain_reader), start_offset))
                 }
                 FilterType::BcjARM => {
                     let start_offset = property as usize;
-                    FilterReader::Bcj(BCJReader::new_arm(Box::new(chain_reader), start_offset))
+                    FilterReader::Bcj(BcjReader::new_arm(Box::new(chain_reader), start_offset))
                 }
                 FilterType::BcjARMThumb => {
                     let start_offset = property as usize;
-                    FilterReader::Bcj(BCJReader::new_arm_thumb(
+                    FilterReader::Bcj(BcjReader::new_arm_thumb(
                         Box::new(chain_reader),
                         start_offset,
                     ))
                 }
                 FilterType::BcjSPARC => {
                     let start_offset = property as usize;
-                    FilterReader::Bcj(BCJReader::new_sparc(Box::new(chain_reader), start_offset))
+                    FilterReader::Bcj(BcjReader::new_sparc(Box::new(chain_reader), start_offset))
                 }
                 FilterType::BcjARM64 => {
                     let start_offset = property as usize;
-                    FilterReader::Bcj(BCJReader::new_arm64(Box::new(chain_reader), start_offset))
+                    FilterReader::Bcj(BcjReader::new_arm64(Box::new(chain_reader), start_offset))
                 }
                 FilterType::BcjRISCV => {
                     let start_offset = property as usize;
-                    FilterReader::Bcj(BCJReader::new_riscv(Box::new(chain_reader), start_offset))
+                    FilterReader::Bcj(BcjReader::new_riscv(Box::new(chain_reader), start_offset))
                 }
                 FilterType::LZMA2 => {
                     let dict_size = property;
-                    FilterReader::LZMA2(LZMA2Reader::new(Box::new(chain_reader), dict_size, None))
+                    FilterReader::LZMA2(Lzma2Reader::new(Box::new(chain_reader), dict_size, None))
                 }
             };
         }
@@ -161,7 +161,7 @@ impl<R: Read> FilterReader<R> {
 }
 
 /// A single-threaded XZ decompressor.
-pub struct XZReader<R: Read> {
+pub struct XzReader<R: Read> {
     reader: FilterReader<R>,
     stream_header: Option<StreamHeader>,
     checksum_calculator: Option<ChecksumCalculator>,
@@ -170,8 +170,8 @@ pub struct XZReader<R: Read> {
     blocks_processed: u64,
 }
 
-impl<R: Read> XZReader<R> {
-    /// Create a new [`XZReader`].
+impl<R: Read> XzReader<R> {
+    /// Create a new [`XzReader`].
     pub fn new(inner: R, allow_multiple_streams: bool) -> Self {
         let reader = FilterReader::Counting(CountingReader::new(inner));
 
@@ -185,7 +185,7 @@ impl<R: Read> XZReader<R> {
         }
     }
 
-    /// Consume the XZReader and return the inner reader.
+    /// Consume the XzReader and return the inner reader.
     pub fn into_inner(self) -> R {
         self.reader.into_inner()
     }
@@ -201,7 +201,7 @@ impl<R: Read> XZReader<R> {
     }
 }
 
-impl<R: Read> XZReader<R> {
+impl<R: Read> XzReader<R> {
     fn ensure_stream_header(&mut self) -> Result<()> {
         if self.stream_header.is_none() {
             let header = StreamHeader::parse(&mut self.reader)?;
@@ -393,7 +393,7 @@ impl<R: Read> XZReader<R> {
     }
 }
 
-impl<R: Read> Read for XZReader<R> {
+impl<R: Read> Read for XzReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         if self.finished {
             return Ok(0);

--- a/src/xz/reader_mt.rs
+++ b/src/xz/reader_mt.rs
@@ -43,7 +43,7 @@ enum State {
 }
 
 /// A multi-threaded XZ decompressor.
-pub struct XZReaderMT<R: Read + Seek> {
+pub struct XzReaderMt<R: Read + Seek> {
     inner: Option<R>,
     blocks: Vec<XZBlock>,
     check_type: CheckType,
@@ -64,7 +64,7 @@ pub struct XZReaderMT<R: Read + Seek> {
     allow_multiple_streams: bool,
 }
 
-impl<R: Read + Seek> XZReaderMT<R> {
+impl<R: Read + Seek> XzReaderMt<R> {
     /// Creates a new multi-threaded XZ reader.
     ///
     /// - `inner`: The reader to read compressed data from. Must implement Seek.
@@ -445,7 +445,7 @@ fn decompress_xz_block(block_data: Vec<u8>, check_type: CheckType) -> io::Result
     Ok(decompressed_data)
 }
 
-impl<R: Read + Seek> Read for XZReaderMT<R> {
+impl<R: Read + Seek> Read for XzReaderMt<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
@@ -471,7 +471,7 @@ impl<R: Read + Seek> Read for XZReaderMT<R> {
     }
 }
 
-impl<R: Read + Seek> Drop for XZReaderMT<R> {
+impl<R: Read + Seek> Drop for XzReaderMt<R> {
     fn drop(&mut self) {
         self.shutdown_flag.store(true, Ordering::Release);
         self.work_queue.close();

--- a/tests/efficiency.rs
+++ b/tests/efficiency.rs
@@ -1,12 +1,12 @@
 use std::io::{Read, Write};
 
-use liblzma::{bufread::*, stream::*};
-use lzma_rust2::{LZMA2Options, LZMA2Writer, LZMAOptions, LZMAWriter};
+use liblzma::{bufread::*, stream};
+use lzma_rust2::{Lzma2Options, Lzma2Writer, LzmaOptions, LzmaWriter};
 
 fn compress_liblzma_lzma1(level: u32, data: &[u8]) -> Vec<u8> {
     let mut compressed = Vec::new();
-    let options = LzmaOptions::new_preset(level).unwrap();
-    let stream = Stream::new_lzma_encoder(&options).unwrap();
+    let options = stream::LzmaOptions::new_preset(level).unwrap();
+    let stream = stream::Stream::new_lzma_encoder(&options).unwrap();
     let mut encoder = XzEncoder::new_stream(data, stream);
     encoder.read_to_end(&mut compressed).unwrap();
     compressed
@@ -14,8 +14,8 @@ fn compress_liblzma_lzma1(level: u32, data: &[u8]) -> Vec<u8> {
 
 fn compress_lzmarust2_lzma1(level: u32, data: &[u8]) -> Vec<u8> {
     let mut compressed = Vec::new();
-    let options = LZMAOptions::with_preset(level);
-    let mut writer = LZMAWriter::new_no_header(&mut compressed, &options, true).unwrap();
+    let options = LzmaOptions::with_preset(level);
+    let mut writer = LzmaWriter::new_no_header(&mut compressed, &options, true).unwrap();
     writer.write_all(data).unwrap();
     writer.finish().unwrap();
     compressed
@@ -23,7 +23,7 @@ fn compress_lzmarust2_lzma1(level: u32, data: &[u8]) -> Vec<u8> {
 
 fn compress_liblzma_lzma2(level: u32, data: &[u8]) -> Vec<u8> {
     let mut compressed = Vec::new();
-    let stream = Stream::new_easy_encoder(level, Check::None).unwrap();
+    let stream = stream::Stream::new_easy_encoder(level, stream::Check::None).unwrap();
     let mut encoder = XzEncoder::new_stream(data, stream);
     encoder.read_to_end(&mut compressed).unwrap();
     compressed
@@ -31,8 +31,8 @@ fn compress_liblzma_lzma2(level: u32, data: &[u8]) -> Vec<u8> {
 
 fn compress_lzmarust2_lzma2(level: u32, data: &[u8]) -> Vec<u8> {
     let mut compressed = Vec::new();
-    let options = LZMA2Options::with_preset(level);
-    let mut writer = LZMA2Writer::new(&mut compressed, options);
+    let options = Lzma2Options::with_preset(level);
+    let mut writer = Lzma2Writer::new(&mut compressed, options);
     writer.write_all(data).unwrap();
     writer.finish().unwrap();
     compressed

--- a/tests/lzip.rs
+++ b/tests/lzip.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use lzma_rust2::{LZIPOptions, LZIPReader, LZIPWriter};
+use lzma_rust2::{LzipOptions, LzipReader, LzipWriter};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -9,12 +9,12 @@ static PG6800: &str = "tests/data/pg6800.txt";
 fn test_round_trip(path: &str, level: u32) {
     let data = std::fs::read(path).unwrap();
 
-    let option = LZIPOptions::with_preset(level);
+    let option = LzipOptions::with_preset(level);
 
     let mut compressed = Vec::new();
 
     {
-        let mut writer = LZIPWriter::new(&mut compressed, option);
+        let mut writer = LzipWriter::new(&mut compressed, option);
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -22,7 +22,7 @@ fn test_round_trip(path: &str, level: u32) {
     let mut uncompressed = Vec::new();
 
     {
-        let mut reader = LZIPReader::new(compressed.as_slice()).unwrap();
+        let mut reader = LzipReader::new(compressed.as_slice()).unwrap();
         reader.read_to_end(&mut uncompressed).unwrap();
     }
 

--- a/tests/lzip_mt.rs
+++ b/tests/lzip_mt.rs
@@ -3,7 +3,7 @@ use std::{
     num::{NonZero, NonZeroU64},
 };
 
-use lzma_rust2::{LZIPOptions, LZIPReaderMT, LZIPWriterMT};
+use lzma_rust2::{LzipOptions, LzipReaderMt, LzipWriterMt};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -18,7 +18,7 @@ fn test_round_trip(path: &str, level: u32) {
         .get()
         .min(256) as u32;
 
-    let mut options = LZIPOptions::with_preset(level);
+    let mut options = LzipOptions::with_preset(level);
     let dict_size = options.lzma_options.dict_size;
     options.set_member_size(NonZeroU64::new(dict_size as u64));
 
@@ -26,7 +26,7 @@ fn test_round_trip(path: &str, level: u32) {
 
     {
         let mut writer =
-            LZIPWriterMT::new(&mut compressed, options, available_parallelism).unwrap();
+            LzipWriterMt::new(&mut compressed, options, available_parallelism).unwrap();
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -35,7 +35,7 @@ fn test_round_trip(path: &str, level: u32) {
 
     {
         let cursor = Cursor::new(compressed);
-        let mut reader = LZIPReaderMT::new(cursor, available_parallelism).unwrap();
+        let mut reader = LzipReaderMt::new(cursor, available_parallelism).unwrap();
         reader.read_to_end(&mut uncompressed).unwrap();
 
         if dict_size < data_len {

--- a/tests/lzip_reference.rs
+++ b/tests/lzip_reference.rs
@@ -1,9 +1,9 @@
 use std::io::Read;
 
-use lzma_rust2::LZIPReader;
+use lzma_rust2::LzipReader;
 
 fn reference_test(compressed: &[u8], original: &[u8]) {
-    let mut reader = LZIPReader::new(compressed).unwrap();
+    let mut reader = LzipReader::new(compressed).unwrap();
 
     let mut uncompressed = Vec::with_capacity(original.len());
     let count = reader.read_to_end(&mut uncompressed).unwrap();

--- a/tests/lzma.rs
+++ b/tests/lzma.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use lzma_rust2::{LZMAOptions, LZMAReader, LZMAWriter};
+use lzma_rust2::{LzmaOptions, LzmaReader, LzmaWriter};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -9,12 +9,12 @@ static PG6800: &str = "tests/data/pg6800.txt";
 fn test_round_trip(path: &str, level: u32) {
     let data = std::fs::read(path).unwrap();
 
-    let option = LZMAOptions::with_preset(level);
+    let option = LzmaOptions::with_preset(level);
 
     let mut compressed = Vec::new();
 
     {
-        let mut writer = LZMAWriter::new_no_header(&mut compressed, &option, true).unwrap();
+        let mut writer = LzmaWriter::new_no_header(&mut compressed, &option, true).unwrap();
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -22,7 +22,7 @@ fn test_round_trip(path: &str, level: u32) {
     let mut uncompressed = Vec::new();
 
     {
-        let mut reader = LZMAReader::new(
+        let mut reader = LzmaReader::new(
             compressed.as_slice(),
             data.len() as u64,
             option.lc,

--- a/tests/lzma2.rs
+++ b/tests/lzma2.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use lzma_rust2::{LZMA2Options, LZMA2Reader, LZMA2Writer};
+use lzma_rust2::{Lzma2Options, Lzma2Reader, Lzma2Writer};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -9,13 +9,13 @@ static PG6800: &str = "tests/data/pg6800.txt";
 fn test_round_trip(path: &str, level: u32) {
     let data = std::fs::read(path).unwrap();
 
-    let option = LZMA2Options::with_preset(level);
+    let option = Lzma2Options::with_preset(level);
     let dict_size = option.lzma_options.dict_size;
 
     let mut compressed = Vec::new();
 
     {
-        let mut writer = LZMA2Writer::new(&mut compressed, option);
+        let mut writer = Lzma2Writer::new(&mut compressed, option);
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -23,7 +23,7 @@ fn test_round_trip(path: &str, level: u32) {
     let mut uncompressed = Vec::new();
 
     {
-        let mut reader = LZMA2Reader::new(compressed.as_slice(), dict_size, None);
+        let mut reader = Lzma2Reader::new(compressed.as_slice(), dict_size, None);
         reader.read_to_end(&mut uncompressed).unwrap();
     }
 

--- a/tests/lzma2_mt.rs
+++ b/tests/lzma2_mt.rs
@@ -3,7 +3,7 @@ use std::{
     num::{NonZero, NonZeroU64},
 };
 
-use lzma_rust2::{LZMA2Options, LZMA2ReaderMT, LZMA2WriterMT};
+use lzma_rust2::{Lzma2Options, Lzma2ReaderMt, Lzma2WriterMt};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -13,7 +13,7 @@ fn test_round_trip(path: &str, level: u32) {
     let data = std::fs::read(path).unwrap();
     let data_len = data.len() as u32;
 
-    let mut option = LZMA2Options::with_preset(level);
+    let mut option = Lzma2Options::with_preset(level);
     let dict_size = option.lzma_options.dict_size;
     option.set_chunk_size(NonZeroU64::new(dict_size as u64));
 
@@ -26,7 +26,7 @@ fn test_round_trip(path: &str, level: u32) {
 
     {
         let mut writer =
-            LZMA2WriterMT::new(&mut compressed, option, available_parallelism).unwrap();
+            Lzma2WriterMt::new(&mut compressed, option, available_parallelism).unwrap();
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -34,7 +34,7 @@ fn test_round_trip(path: &str, level: u32) {
     let mut uncompressed = Vec::new();
 
     {
-        let mut reader = LZMA2ReaderMT::new(
+        let mut reader = Lzma2ReaderMt::new(
             Cursor::new(compressed),
             dict_size,
             None,

--- a/tests/multi_writer.rs
+++ b/tests/multi_writer.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use lzma_rust2::{
-    LZIPOptions, LZIPReaderMT, LZIPWriter, LZMA2Options, LZMA2ReaderMT, LZMA2Writer, XZOptions,
-    XZReaderMT, XZWriter,
+    LzipOptions, LzipReaderMt, LzipWriter, Lzma2Options, Lzma2ReaderMt, Lzma2Writer, XzOptions,
+    XzReaderMt, XzWriter,
 };
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
@@ -15,14 +15,14 @@ const LEVEL: u32 = 3;
 fn multi_writer_lzma2() {
     let data = std::fs::read(EXECUTABLE).unwrap();
 
-    let mut option = LZMA2Options::with_preset(LEVEL);
+    let mut option = Lzma2Options::with_preset(LEVEL);
     let dict_size = option.lzma_options.dict_size;
     option.set_chunk_size(NonZeroU64::new(dict_size as u64));
 
     let mut compressed = Vec::new();
 
     {
-        let mut writer = LZMA2Writer::new(&mut compressed, option);
+        let mut writer = Lzma2Writer::new(&mut compressed, option);
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -30,7 +30,7 @@ fn multi_writer_lzma2() {
     let mut uncompressed = Vec::new();
 
     {
-        let mut reader = LZMA2ReaderMT::new(Cursor::new(compressed), dict_size, None, 1);
+        let mut reader = Lzma2ReaderMt::new(Cursor::new(compressed), dict_size, None, 1);
         reader.read_to_end(&mut uncompressed).unwrap();
         assert!(reader.chunk_count() > 1);
     }
@@ -43,14 +43,14 @@ fn multi_writer_lzma2() {
 fn multi_writer_lzip2() {
     let data = std::fs::read(EXECUTABLE).unwrap();
 
-    let mut option = LZIPOptions::with_preset(LEVEL);
+    let mut option = LzipOptions::with_preset(LEVEL);
     let dict_size = option.lzma_options.dict_size;
     option.set_member_size(NonZeroU64::new(dict_size as u64));
 
     let mut compressed = Vec::new();
 
     {
-        let mut writer = LZIPWriter::new(&mut compressed, option);
+        let mut writer = LzipWriter::new(&mut compressed, option);
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -58,7 +58,7 @@ fn multi_writer_lzip2() {
     let mut uncompressed = Vec::new();
 
     {
-        let mut reader = LZIPReaderMT::new(Cursor::new(compressed), 1).unwrap();
+        let mut reader = LzipReaderMt::new(Cursor::new(compressed), 1).unwrap();
         reader.read_to_end(&mut uncompressed).unwrap();
         assert!(reader.member_count() > 1);
     }
@@ -71,14 +71,14 @@ fn multi_writer_lzip2() {
 fn multi_writer_xz() {
     let data = std::fs::read(EXECUTABLE).unwrap();
 
-    let mut option = XZOptions::with_preset(LEVEL);
+    let mut option = XzOptions::with_preset(LEVEL);
     let dict_size = option.lzma_options.dict_size;
     option.set_block_size(NonZeroU64::new(dict_size as u64));
 
     let mut compressed = Vec::new();
 
     {
-        let mut writer = XZWriter::new(&mut compressed, option).unwrap();
+        let mut writer = XzWriter::new(&mut compressed, option).unwrap();
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -86,7 +86,7 @@ fn multi_writer_xz() {
     let mut uncompressed = Vec::new();
 
     {
-        let mut reader = XZReaderMT::new(Cursor::new(compressed), false, 1).unwrap();
+        let mut reader = XzReaderMt::new(Cursor::new(compressed), false, 1).unwrap();
         reader.read_to_end(&mut uncompressed).unwrap();
         assert!(reader.block_count() > 1);
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,12 +1,12 @@
 use std::io::Read;
 
-use lzma_rust2::LZMA2ReaderMT;
+use lzma_rust2::Lzma2ReaderMt;
 
 fn regression_lzma2_reader_mt(input_data: &[u8], expected_output: &[u8], dict_size: u32) {
     let mut uncompressed = Vec::new();
 
     {
-        let mut reader = LZMA2ReaderMT::new(input_data, dict_size, None, 1);
+        let mut reader = Lzma2ReaderMt::new(input_data, dict_size, None, 1);
         reader.read_to_end(&mut uncompressed).unwrap();
     }
 

--- a/tests/xz.rs
+++ b/tests/xz.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use lzma_rust2::{XZOptions, XZReader, XZWriter};
+use lzma_rust2::{XzOptions, XzReader, XzWriter};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -9,12 +9,12 @@ static PG6800: &str = "tests/data/pg6800.txt";
 fn test_round_trip(path: &str, level: u32) {
     let data = std::fs::read(path).unwrap();
 
-    let option = XZOptions::with_preset(level);
+    let option = XzOptions::with_preset(level);
 
     let mut compressed = Vec::new();
 
     {
-        let mut writer = XZWriter::new(&mut compressed, option).unwrap();
+        let mut writer = XzWriter::new(&mut compressed, option).unwrap();
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
@@ -22,7 +22,7 @@ fn test_round_trip(path: &str, level: u32) {
     // Test decompression with our own reader
     let mut uncompressed = Vec::new();
     {
-        let mut reader = XZReader::new(compressed.as_slice(), false);
+        let mut reader = XzReader::new(compressed.as_slice(), false);
         reader.read_to_end(&mut uncompressed).unwrap();
     }
 

--- a/tests/xz_mt.rs
+++ b/tests/xz_mt.rs
@@ -3,7 +3,7 @@ use std::{
     num::NonZeroU64,
 };
 
-use lzma_rust2::{XZOptions, XZReaderMT, XZWriterMT};
+use lzma_rust2::{XzOptions, XzReaderMt, XzWriterMt};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -12,21 +12,21 @@ static PG6800: &str = "tests/data/pg6800.txt";
 fn test_round_trip(path: &str, level: u32) {
     let data = std::fs::read(path).unwrap();
 
-    let mut options = XZOptions::with_preset(level);
+    let mut options = XzOptions::with_preset(level);
     let dict_size = options.lzma_options.dict_size as u64;
     options.set_block_size(NonZeroU64::new(dict_size));
 
     let mut compressed = Vec::new();
 
     {
-        let mut writer = XZWriterMT::new(&mut compressed, options, 2).unwrap();
+        let mut writer = XzWriterMt::new(&mut compressed, options, 2).unwrap();
         writer.write_all(&data).unwrap();
         writer.finish().unwrap();
     }
 
     let mut uncompressed = Vec::new();
     {
-        let mut reader = XZReaderMT::new(Cursor::new(compressed.as_slice()), false, 2).unwrap();
+        let mut reader = XzReaderMt::new(Cursor::new(compressed.as_slice()), false, 2).unwrap();
         let data_len = reader.read_to_end(&mut uncompressed).unwrap();
 
         if dict_size < data_len as u64 {

--- a/tests/xz_reference.rs
+++ b/tests/xz_reference.rs
@@ -1,9 +1,9 @@
 use std::io::Read;
 
-use lzma_rust2::XZReader;
+use lzma_rust2::XzReader;
 
 fn reference_test(compressed: &[u8], original: &[u8]) {
-    let mut reader = XZReader::new(compressed, false);
+    let mut reader = XzReader::new(compressed, false);
 
     let mut uncompressed = Vec::with_capacity(original.len());
     let count = reader.read_to_end(&mut uncompressed).unwrap();


### PR DESCRIPTION
This renames identifiers of the public API to follow the Rust API Guidelines. This does not define any type aliases.

The identifiers were replaced by the following command:

```sh
sd "LZMAOptions" "LzmaOptions" (rg -l "LZMAOptions")
```

Therefore, if there is a private identifier with the same name as a public identifier, it is also replaced. Files that should not be replaced, such as `CHANGELOG.md`, are excluded.

Closes #34