### PR TITLE
style: Rename private identifiers to follow Rust API Guidelines

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,20 +1,20 @@
 use alloc::{vec, vec::Vec};
 
 use super::{
-    coder_get_dict_size, lz::LZDecoder, range_dec::RangeDecoder, LZMACoder, LengthCoder,
-    LiteralCoder, LiteralSubCoder, ALIGN_BITS, DIST_MODEL_END, DIST_MODEL_START, LOW_SYMBOLS,
+    coder_get_dict_size, lz::LzDecoder, range_dec::RangeDecoder, LengthCoder, LiteralCoder,
+    LiteralSubCoder, LzmaCoder, ALIGN_BITS, DIST_MODEL_END, DIST_MODEL_START, LOW_SYMBOLS,
     MATCH_LEN_MIN, MID_SYMBOLS,
 };
 use crate::range_dec::RangeReader;
 
-pub(crate) struct LZMADecoder {
-    coder: LZMACoder,
+pub(crate) struct LzmaDecoder {
+    coder: LzmaCoder,
     literal_decoder: LiteralDecoder,
     match_len_decoder: LengthCoder,
     rep_len_decoder: LengthCoder,
 }
 
-impl LZMADecoder {
+impl LzmaDecoder {
     pub(crate) fn new(lc: u32, lp: u32, pb: u32) -> Self {
         let mut literal_decoder = LiteralDecoder::new(lc, lp);
         literal_decoder.reset();
@@ -29,7 +29,7 @@ impl LZMADecoder {
             l
         };
         Self {
-            coder: LZMACoder::new(pb as _),
+            coder: LzmaCoder::new(pb as _),
             literal_decoder,
             match_len_decoder,
             rep_len_decoder,
@@ -49,7 +49,7 @@ impl LZMADecoder {
 
     pub(crate) fn decode<R: RangeReader>(
         &mut self,
-        lz: &mut LZDecoder,
+        lz: &mut LzDecoder,
         rc: &mut RangeDecoder<R>,
     ) -> crate::Result<()> {
         lz.repeat_pending()?;
@@ -163,8 +163,8 @@ impl LiteralDecoder {
 
     fn decode<R: RangeReader>(
         &mut self,
-        coder: &mut LZMACoder,
-        lz: &mut LZDecoder,
+        coder: &mut LzmaCoder,
+        lz: &mut LzDecoder,
         rc: &mut RangeDecoder<R>,
     ) -> crate::Result<()> {
         let i = self
@@ -189,8 +189,8 @@ impl LiteralSubDecoder {
 
     pub(crate) fn decode<R: RangeReader>(
         &mut self,
-        coder: &mut LZMACoder,
-        lz: &mut LZDecoder,
+        coder: &mut LzmaCoder,
+        lz: &mut LzDecoder,
         rc: &mut RangeDecoder<R>,
     ) -> crate::Result<()> {
         let mut symbol: u32 = 1;

--- a/src/enc/encoder_fast.rs
+++ b/src/enc/encoder_fast.rs
@@ -1,6 +1,6 @@
 use super::{
-    encoder::LZMAEncoderTrait,
-    lz::{LZEncoder, MfType},
+    encoder::LzmaEncoderTrait,
+    lz::{LzEncoder, MfType},
     MATCH_LEN_MAX, MATCH_LEN_MIN, REPS,
 };
 
@@ -12,7 +12,7 @@ impl FastEncoderMode {
     pub(crate) const EXTRA_SIZE_AFTER: u32 = MATCH_LEN_MAX as u32 - 1;
 
     pub(crate) fn get_memory_usage(dict_size: u32, extra_size_before: u32, mf: MfType) -> u32 {
-        LZEncoder::get_memory_usage(
+        LzEncoder::get_memory_usage(
             dict_size,
             extra_size_before.max(Self::EXTRA_SIZE_BEFORE),
             Self::EXTRA_SIZE_AFTER,
@@ -26,8 +26,8 @@ fn change_pair(small_dist: u32, big_dist: u32) -> bool {
     small_dist < (big_dist >> 7)
 }
 
-impl LZMAEncoderTrait for FastEncoderMode {
-    fn get_next_symbol(&mut self, encoder: &mut super::encoder::LZMAEncoder) -> u32 {
+impl LzmaEncoderTrait for FastEncoderMode {
+    fn get_next_symbol(&mut self, encoder: &mut super::encoder::LzmaEncoder) -> u32 {
         if encoder.data.read_ahead == -1 {
             encoder.find_matches();
         }

--- a/src/enc/encoder_normal.rs
+++ b/src/enc/encoder_normal.rs
@@ -1,8 +1,8 @@
 use alloc::{vec, vec::Vec};
 
 use super::{
-    encoder::{LZMAEncoder, LZMAEncoderTrait},
-    lz::{LZEncoder, MfType},
+    encoder::{LzmaEncoder, LzmaEncoderTrait},
+    lz::{LzEncoder, MfType},
     state::State,
     MATCH_LEN_MAX, MATCH_LEN_MIN, REPS,
 };
@@ -21,7 +21,7 @@ impl NormalEncoderMode {
     pub(crate) const EXTRA_SIZE_AFTER: u32 = Self::OPTS;
 
     pub(crate) fn get_memory_usage(dict_size: u32, extra_size_before: u32, mf: MfType) -> u32 {
-        LZEncoder::get_memory_usage(
+        LzEncoder::get_memory_usage(
             dict_size,
             extra_size_before.max(Self::EXTRA_SIZE_BEFORE),
             Self::EXTRA_SIZE_AFTER,
@@ -38,7 +38,7 @@ impl NormalEncoderMode {
         }
     }
 
-    fn convert_opts(&mut self, encoder: &mut LZMAEncoder) -> usize {
+    fn convert_opts(&mut self, encoder: &mut LzmaEncoder) -> usize {
         self.opt_end = self.opt_cur;
 
         let mut opt_prev = self.opts[self.opt_cur].opt_prev;
@@ -147,7 +147,7 @@ impl NormalEncoderMode {
 
     fn calc1_byte_prices(
         &mut self,
-        encoder: &mut LZMAEncoder,
+        encoder: &mut LzmaEncoder,
         pos: u32,
         pos_state: u32,
         avail: i32,
@@ -220,7 +220,7 @@ impl NormalEncoderMode {
 
     fn calc_long_rep_prices(
         &mut self,
-        encoder: &mut LZMAEncoder,
+        encoder: &mut LzmaEncoder,
         pos: u32,
         pos_state: u32,
         avail: i32,
@@ -319,7 +319,7 @@ impl NormalEncoderMode {
 
     fn calc_normal_match_prices(
         &mut self,
-        encoder: &mut LZMAEncoder,
+        encoder: &mut LzmaEncoder,
         pos: u32,
         pos_state: u32,
         avail: i32,
@@ -422,8 +422,8 @@ impl NormalEncoderMode {
     }
 }
 
-impl LZMAEncoderTrait for NormalEncoderMode {
-    fn get_next_symbol(&mut self, encoder: &mut LZMAEncoder) -> u32 {
+impl LzmaEncoderTrait for NormalEncoderMode {
+    fn get_next_symbol(&mut self, encoder: &mut LzmaEncoder) -> u32 {
         // If there are pending symbols from an earlier call to this
         // function, return those symbols first.
         let pos = encoder.lz.get_pos();

--- a/src/enc/lzma2_writer.rs
+++ b/src/enc/lzma2_writer.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::num::NonZeroU64;
 
 use super::{
-    encoder::{EncodeMode, LZMAEncoder, LZMAEncoderModes},
+    encoder::{EncodeMode, LzmaEncoder, LzmaEncoderModes},
     lz::MfType,
     range_enc::{RangeEncoder, RangeEncoderBuffer},
 };
@@ -145,7 +145,7 @@ impl LzmaOptions {
     pub fn get_memory_usage(&self) -> u32 {
         let dict_size = self.dict_size;
         let extra_size_before = get_extra_size_before(dict_size);
-        70 + LZMAEncoder::get_mem_usage(self.mode, dict_size, extra_size_before, self.mf)
+        70 + LzmaEncoder::get_mem_usage(self.mode, dict_size, extra_size_before, self.mf)
     }
 
     /// Returns the LZMA properties byte for these options.
@@ -193,8 +193,8 @@ pub fn get_extra_size_before(dict_size: u32) -> u32 {
 pub struct Lzma2Writer<W: Write> {
     inner: W,
     rc: RangeEncoder<RangeEncoderBuffer>,
-    lzma: LZMAEncoder,
-    mode: LZMAEncoderModes,
+    lzma: LzmaEncoder,
+    mode: LzmaEncoderModes,
     dict_reset_needed: bool,
     state_reset_needed: bool,
     props_needed: bool,
@@ -212,7 +212,7 @@ impl<W: Write> Lzma2Writer<W> {
         let dict_size = lzma_options.dict_size;
 
         let rc = RangeEncoder::new_buffer(COMPRESSED_SIZE_MAX as usize);
-        let (mut lzma, mode) = LZMAEncoder::new(
+        let (mut lzma, mode) = LzmaEncoder::new(
             lzma_options.mode,
             lzma_options.lc,
             lzma_options.lp,
@@ -272,7 +272,7 @@ impl<W: Write> Lzma2Writer<W> {
 
         let lzma_options = &self.options.lzma_options;
 
-        let (new_lzma, new_mode) = LZMAEncoder::new(
+        let (new_lzma, new_mode) = LzmaEncoder::new(
             lzma_options.mode,
             lzma_options.lc,
             lzma_options.lp,

--- a/src/enc/lzma_writer.rs
+++ b/src/enc/lzma_writer.rs
@@ -1,5 +1,5 @@
 use super::{
-    encoder::{LZMAEncoder, LZMAEncoderModes},
+    encoder::{LzmaEncoder, LzmaEncoderModes},
     range_enc::RangeEncoder,
     LzmaOptions,
 };
@@ -8,12 +8,12 @@ use crate::{error_invalid_input, error_unsupported, Write};
 /// A single-threaded LZMA compressor.
 pub struct LzmaWriter<W: Write> {
     rc: RangeEncoder<W>,
-    lzma: LZMAEncoder,
+    lzma: LzmaEncoder,
     use_end_marker: bool,
     current_uncompressed_size: u64,
     expected_uncompressed_size: Option<u64>,
     props: u8,
-    mode: LZMAEncoderModes,
+    mode: LzmaEncoderModes,
 }
 
 impl<W: Write> LzmaWriter<W> {
@@ -25,7 +25,7 @@ impl<W: Write> LzmaWriter<W> {
         use_end_marker: bool,
         expected_uncompressed_size: Option<u64>,
     ) -> crate::Result<LzmaWriter<W>> {
-        let (mut lzma, mode) = LZMAEncoder::new(
+        let (mut lzma, mode) = LzmaEncoder::new(
             options.mode,
             options.lc,
             options.lp,

--- a/src/filter/bcj.rs
+++ b/src/filter/bcj.rs
@@ -13,16 +13,16 @@ use crate::Read;
 #[cfg(feature = "encoder")]
 use crate::Write;
 
-struct BCJFilter {
+struct BcjFilter {
     is_encoder: bool,
     pos: usize,
     prev_mask: u32,
     filter: FilterFn,
 }
 
-type FilterFn = fn(filter: &mut BCJFilter, buf: &mut [u8]) -> usize;
+type FilterFn = fn(filter: &mut BcjFilter, buf: &mut [u8]) -> usize;
 
-impl BCJFilter {
+impl BcjFilter {
     #[inline]
     fn code(&mut self, buf: &mut [u8]) -> usize {
         let filter = self.filter;
@@ -35,7 +35,7 @@ const FILTER_BUF_SIZE: usize = 4096;
 /// Reader that applies BCJ (Branch/Call/Jump) filtering to compressed data.
 pub struct BcjReader<R> {
     inner: R,
-    filter: BCJFilter,
+    filter: BcjFilter,
     state: State,
 }
 
@@ -49,7 +49,7 @@ struct State {
 }
 
 impl<R> BcjReader<R> {
-    fn new(inner: R, filter: BCJFilter) -> Self {
+    fn new(inner: R, filter: BcjFilter) -> Self {
         Self {
             inner,
             filter,
@@ -78,49 +78,49 @@ impl<R> BcjReader<R> {
     /// Creates a new BCJ reader for x86 instruction filtering.
     #[inline]
     pub fn new_x86(inner: R, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_x86(start_pos, false))
+        Self::new(inner, BcjFilter::new_x86(start_pos, false))
     }
 
     /// Creates a new BCJ reader for ARM instruction filtering.
     #[inline]
     pub fn new_arm(inner: R, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_arm(start_pos, false))
+        Self::new(inner, BcjFilter::new_arm(start_pos, false))
     }
 
     /// Creates a new BCJ reader for ARM64 instruction filtering.
     #[inline]
     pub fn new_arm64(inner: R, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_arm64(start_pos, false))
+        Self::new(inner, BcjFilter::new_arm64(start_pos, false))
     }
 
     /// Creates a new BCJ reader for ARM Thumb instruction filtering.
     #[inline]
     pub fn new_arm_thumb(inner: R, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_arm_thumb(start_pos, false))
+        Self::new(inner, BcjFilter::new_arm_thumb(start_pos, false))
     }
 
     /// Creates a new BCJ reader for PowerPC instruction filtering.
     #[inline]
     pub fn new_ppc(inner: R, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_power_pc(start_pos, false))
+        Self::new(inner, BcjFilter::new_power_pc(start_pos, false))
     }
 
     /// Creates a new BCJ reader for SPARC instruction filtering.
     #[inline]
     pub fn new_sparc(inner: R, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_sparc(start_pos, false))
+        Self::new(inner, BcjFilter::new_sparc(start_pos, false))
     }
 
     /// Creates a new BCJ reader for IA-64 instruction filtering.
     #[inline]
     pub fn new_ia64(inner: R, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_ia64(start_pos, false))
+        Self::new(inner, BcjFilter::new_ia64(start_pos, false))
     }
 
     /// Creates a new BCJ reader for RISC-V instruction filtering.
     #[inline]
     pub fn new_riscv(inner: R, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_riscv(start_pos, false))
+        Self::new(inner, BcjFilter::new_riscv(start_pos, false))
     }
 }
 
@@ -199,13 +199,13 @@ impl<R: Read> Read for BcjReader<R> {
 #[cfg(feature = "encoder")]
 pub struct BcjWriter<W> {
     inner: W,
-    filter: BCJFilter,
+    filter: BcjFilter,
     buffer: Vec<u8>,
 }
 
 #[cfg(feature = "encoder")]
 impl<W> BcjWriter<W> {
-    fn new(inner: W, filter: BCJFilter) -> Self {
+    fn new(inner: W, filter: BcjFilter) -> Self {
         Self {
             inner,
             filter,
@@ -231,49 +231,49 @@ impl<W> BcjWriter<W> {
     /// Creates a new BCJ writer for x86 instruction filtering.
     #[inline]
     pub fn new_x86(inner: W, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_x86(start_pos, true))
+        Self::new(inner, BcjFilter::new_x86(start_pos, true))
     }
 
     /// Creates a new BCJ writer for ARM instruction filtering.
     #[inline]
     pub fn new_arm(inner: W, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_arm(start_pos, true))
+        Self::new(inner, BcjFilter::new_arm(start_pos, true))
     }
 
     /// Creates a new BCJ writer for ARM64 instruction filtering.
     #[inline]
     pub fn new_arm64(inner: W, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_arm64(start_pos, true))
+        Self::new(inner, BcjFilter::new_arm64(start_pos, true))
     }
 
     /// Creates a new BCJ writer for ARM Thumb instruction filtering.
     #[inline]
     pub fn new_arm_thumb(inner: W, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_arm_thumb(start_pos, true))
+        Self::new(inner, BcjFilter::new_arm_thumb(start_pos, true))
     }
 
     /// Creates a new BCJ writer for PowerPC instruction filtering.
     #[inline]
     pub fn new_ppc(inner: W, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_power_pc(start_pos, true))
+        Self::new(inner, BcjFilter::new_power_pc(start_pos, true))
     }
 
     /// Creates a new BCJ writer for SPARC instruction filtering.
     #[inline]
     pub fn new_sparc(inner: W, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_sparc(start_pos, true))
+        Self::new(inner, BcjFilter::new_sparc(start_pos, true))
     }
 
     /// Creates a new BCJ writer for IA-64 instruction filtering.
     #[inline]
     pub fn new_ia64(inner: W, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_ia64(start_pos, true))
+        Self::new(inner, BcjFilter::new_ia64(start_pos, true))
     }
 
     /// Creates a new BCJ writer for RISC-V instruction filtering.
     #[inline]
     pub fn new_riscv(inner: W, start_pos: usize) -> Self {
-        Self::new(inner, BCJFilter::new_riscv(start_pos, true))
+        Self::new(inner, BcjFilter::new_riscv(start_pos, true))
     }
 
     /// Finishes writing by flushing any remaining unprocessed data.

--- a/src/filter/bcj/arm.rs
+++ b/src/filter/bcj/arm.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl BCJFilter {
+impl BcjFilter {
     pub(crate) fn new_arm(start_pos: usize, encoder: bool) -> Self {
         Self {
             is_encoder: encoder,

--- a/src/filter/bcj/ia64.rs
+++ b/src/filter/bcj/ia64.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl BCJFilter {
+impl BcjFilter {
     pub(crate) fn new_ia64(start_pos: usize, encoder: bool) -> Self {
         Self {
             is_encoder: encoder,

--- a/src/filter/bcj/ppc.rs
+++ b/src/filter/bcj/ppc.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl BCJFilter {
+impl BcjFilter {
     pub(crate) fn new_power_pc(start_pos: usize, encoder: bool) -> Self {
         Self {
             is_encoder: encoder,

--- a/src/filter/bcj/riscv.rs
+++ b/src/filter/bcj/riscv.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl BCJFilter {
+impl BcjFilter {
     pub(crate) fn new_riscv(start_pos: usize, encoder: bool) -> Self {
         Self {
             is_encoder: encoder,

--- a/src/filter/bcj/sparc.rs
+++ b/src/filter/bcj/sparc.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl BCJFilter {
+impl BcjFilter {
     pub(crate) fn new_sparc(start_pos: usize, encoder: bool) -> Self {
         Self {
             is_encoder: encoder,

--- a/src/filter/bcj/x86.rs
+++ b/src/filter/bcj/x86.rs
@@ -9,7 +9,7 @@ const fn test_86_ms_byte(b: u8) -> bool {
     b == 0x00 || b == 0xFF
 }
 
-impl BCJFilter {
+impl BcjFilter {
     pub(crate) fn new_x86(start_pos: usize, encoder: bool) -> Self {
         Self {
             is_encoder: encoder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ fn set_error(
     shutdown_flag.store(true, std::sync::atomic::Ordering::Release);
 }
 
-pub(crate) struct LZMACoder {
+pub(crate) struct LzmaCoder {
     pub(crate) pos_mask: u32,
     pub(crate) reps: [i32; REPS],
     pub(crate) state: State,
@@ -212,7 +212,7 @@ pub(crate) fn get_dist_state(len: u32) -> u32 {
     }) as u32
 }
 
-impl LZMACoder {
+impl LzmaCoder {
     pub(crate) fn new(pb: usize) -> Self {
         let mut c = Self {
             pos_mask: (1 << pb) - 1,
@@ -464,7 +464,7 @@ fn copy_error(error: &Error) -> Error {
 #[cfg(not(feature = "std"))]
 #[inline(always)]
 fn error_eof() -> Error {
-    Error::EOF
+    Error::Eof
 }
 
 #[cfg(not(feature = "std"))]

--- a/src/lz/bt4.rs
+++ b/src/lz/bt4.rs
@@ -1,6 +1,6 @@
 use alloc::{vec, vec::Vec};
 
-use super::{extend_match, hash234::Hash234, LZEncoder, MatchFind, Matches};
+use super::{extend_match, hash234::Hash234, LzEncoder, MatchFind, Matches};
 
 /// Binary Tree with 4-byte matching
 pub(crate) struct Bt4 {
@@ -43,14 +43,14 @@ impl Bt4 {
         Hash234::get_mem_usage(dict_size) + dict_size / (1024 / 8) + 10
     }
 
-    fn move_pos(&mut self, encoder: &mut super::LZEncoderData) -> i32 {
+    fn move_pos(&mut self, encoder: &mut super::LzEncoderData) -> i32 {
         let avail = encoder.move_pos(encoder.nice_len as _, 4);
         if avail != 0 {
             self.lz_pos += 1;
             if self.lz_pos == MAX_POS {
                 let normalization_offset = MAX_POS - self.cyclic_size;
                 self.hash.normalize(normalization_offset);
-                LZEncoder::normalize(&mut self.tree, normalization_offset);
+                LzEncoder::normalize(&mut self.tree, normalization_offset);
                 self.lz_pos -= normalization_offset;
             }
             self.cyclic_pos += 1;
@@ -63,7 +63,7 @@ impl Bt4 {
 
     fn skip(
         &mut self,
-        encoder: &mut super::LZEncoderData,
+        encoder: &mut super::LzEncoderData,
         nice_len_limit: i32,
         mut current_match: i32,
     ) {
@@ -124,7 +124,7 @@ impl Bt4 {
 }
 
 impl MatchFind for Bt4 {
-    fn find_matches(&mut self, encoder: &mut super::LZEncoderData, matches: &mut Matches) {
+    fn find_matches(&mut self, encoder: &mut super::LzEncoderData, matches: &mut Matches) {
         matches.count = 0;
 
         let mut match_len_limit = encoder.match_len_max as i32;
@@ -265,7 +265,7 @@ impl MatchFind for Bt4 {
         }
     }
 
-    fn skip(&mut self, encoder: &mut super::LZEncoderData, len: usize) {
+    fn skip(&mut self, encoder: &mut super::LzEncoderData, len: usize) {
         let mut len = len as i32;
         while {
             let n = len > 0;

--- a/src/lz/hash234.rs
+++ b/src/lz/hash234.rs
@@ -1,6 +1,6 @@
 use alloc::{vec, vec::Vec};
 
-use super::LZEncoder;
+use super::LzEncoder;
 
 const HASH2_SIZE: u32 = 1 << 10;
 const HASH2_MASK: u32 = HASH2_SIZE - 1;
@@ -93,9 +93,9 @@ impl Hash234 {
     }
 
     pub(crate) fn normalize(&mut self, offset: i32) {
-        LZEncoder::normalize(&mut self.hash2_table, offset);
-        LZEncoder::normalize(&mut self.hash3_table, offset);
-        LZEncoder::normalize(&mut self.hash4_table, offset);
+        LzEncoder::normalize(&mut self.hash2_table, offset);
+        LzEncoder::normalize(&mut self.hash3_table, offset);
+        LzEncoder::normalize(&mut self.hash4_table, offset);
     }
 }
 

--- a/src/lz/hc4.rs
+++ b/src/lz/hc4.rs
@@ -3,8 +3,8 @@ use alloc::{vec, vec::Vec};
 use super::{
     extend_match,
     hash234::Hash234,
-    lz_encoder::{LZEncoder, MatchFind, Matches},
-    LZEncoderData,
+    lz_encoder::{LzEncoder, MatchFind, Matches},
+    LzEncoderData,
 };
 
 /// Hash Chain with 4-byte matching
@@ -39,14 +39,14 @@ impl Hc4 {
         }
     }
 
-    fn move_pos(&mut self, encoder: &mut LZEncoderData) -> i32 {
+    fn move_pos(&mut self, encoder: &mut LzEncoderData) -> i32 {
         let avail = encoder.move_pos(4, 4);
         if avail != 0 {
             self.lz_pos += 1;
             if self.lz_pos == 0x7FFFFFFF {
                 let norm_offset = 0x7FFFFFFF - self.cyclic_size;
                 self.hash.normalize(norm_offset);
-                LZEncoder::normalize(&mut self.chain, norm_offset);
+                LzEncoder::normalize(&mut self.chain, norm_offset);
                 self.lz_pos = self.lz_pos.wrapping_sub(norm_offset);
             }
 
@@ -61,7 +61,7 @@ impl Hc4 {
 }
 
 impl MatchFind for Hc4 {
-    fn find_matches(&mut self, encoder: &mut LZEncoderData, matches: &mut Matches) {
+    fn find_matches(&mut self, encoder: &mut LzEncoderData, matches: &mut Matches) {
         matches.count = 0;
         let mut match_len_limit = encoder.match_len_max as i32;
         let mut nice_len_limit = encoder.nice_len as i32;
@@ -179,7 +179,7 @@ impl MatchFind for Hc4 {
         }
     }
 
-    fn skip(&mut self, encoder: &mut LZEncoderData, mut len: usize) {
+    fn skip(&mut self, encoder: &mut LzEncoderData, mut len: usize) {
         while len > 0 {
             len -= 1;
             if self.move_pos(encoder) != 0 {

--- a/src/lz/lz_decoder.rs
+++ b/src/lz/lz_decoder.rs
@@ -3,7 +3,7 @@ use alloc::{vec, vec::Vec};
 use crate::{error_other, Read};
 
 #[derive(Default)]
-pub(crate) struct LZDecoder {
+pub(crate) struct LzDecoder {
     buf: Vec<u8>,
     buf_size: usize,
     start: usize,
@@ -14,7 +14,7 @@ pub(crate) struct LZDecoder {
     pending_dist: usize,
 }
 
-impl LZDecoder {
+impl LzDecoder {
     pub(crate) fn new(dict_size: usize, preset_dict: Option<&[u8]>) -> Self {
         let mut buf = vec![0; dict_size];
         let mut pos = 0;

--- a/src/lz/lz_encoder.rs
+++ b/src/lz/lz_encoder.rs
@@ -9,8 +9,8 @@ const MOVE_BLOCK_ALIGN: i32 = 64;
 const MOVE_BLOCK_ALIGN_MASK: i32 = !(MOVE_BLOCK_ALIGN - 1);
 
 pub(crate) trait MatchFind {
-    fn find_matches(&mut self, encoder: &mut LZEncoderData, matches: &mut Matches);
-    fn skip(&mut self, encoder: &mut LZEncoderData, len: usize);
+    fn find_matches(&mut self, encoder: &mut LzEncoderData, matches: &mut Matches);
+    fn skip(&mut self, encoder: &mut LzEncoderData, len: usize);
 }
 
 pub(crate) enum MatchFinders {
@@ -19,14 +19,14 @@ pub(crate) enum MatchFinders {
 }
 
 impl MatchFind for MatchFinders {
-    fn find_matches(&mut self, encoder: &mut LZEncoderData, matches: &mut Matches) {
+    fn find_matches(&mut self, encoder: &mut LzEncoderData, matches: &mut Matches) {
         match self {
             MatchFinders::Hc4(m) => m.find_matches(encoder, matches),
             MatchFinders::Bt4(m) => m.find_matches(encoder, matches),
         }
     }
 
-    fn skip(&mut self, encoder: &mut LZEncoderData, len: usize) {
+    fn skip(&mut self, encoder: &mut LzEncoderData, len: usize) {
         match self {
             MatchFinders::Hc4(m) => m.skip(encoder, len),
             MatchFinders::Bt4(m) => m.skip(encoder, len),
@@ -59,13 +59,13 @@ impl MfType {
     }
 }
 
-pub(crate) struct LZEncoder {
-    pub(crate) data: LZEncoderData,
+pub(crate) struct LzEncoder {
+    pub(crate) data: LzEncoderData,
     pub(crate) matches: Matches,
     pub(crate) match_finder: MatchFinders,
 }
 
-pub(crate) struct LZEncoderData {
+pub(crate) struct LzEncoderData {
     pub(crate) keep_size_before: u32,
     pub(crate) keep_size_after: u32,
     pub(crate) match_len_max: u32,
@@ -96,7 +96,7 @@ impl Matches {
     }
 }
 
-impl LZEncoder {
+impl LzEncoder {
     pub(crate) fn get_memory_usage(
         dict_size: u32,
         extra_size_before: u32,
@@ -170,7 +170,7 @@ impl LZEncoder {
         let keep_size_after = extra_size_after + match_len_max;
 
         Self {
-            data: LZEncoderData {
+            data: LzEncoderData {
                 keep_size_before,
                 keep_size_after,
                 match_len_max,
@@ -248,7 +248,7 @@ impl LZEncoder {
     }
 }
 
-impl LZEncoderData {
+impl LzEncoderData {
     pub(crate) fn is_started(&self) -> bool {
         self.read_pos != -1
     }
@@ -453,8 +453,8 @@ impl LZEncoderData {
     }
 }
 
-impl Deref for LZEncoder {
-    type Target = LZEncoderData;
+impl Deref for LzEncoder {
+    type Target = LzEncoderData;
 
     fn deref(&self) -> &Self::Target {
         &self.data

--- a/src/lzip.rs
+++ b/src/lzip.rs
@@ -40,12 +40,12 @@ const MIN_DICT_SIZE: u32 = 4 * 1024;
 const MAX_DICT_SIZE: u32 = 512 * 1024 * 1024;
 
 #[derive(Debug, Clone)]
-pub(crate) struct LZIPHeader {
+pub(crate) struct LzipHeader {
     version: u8,
     dict_size: u32,
 }
 
-impl LZIPHeader {
+impl LzipHeader {
     fn parse<R: Read>(reader: &mut R) -> Result<Self> {
         let mut magic = [0u8; 4];
         reader.read_exact(&mut magic)?;
@@ -62,24 +62,24 @@ impl LZIPHeader {
         let dict_size_byte = reader.read_u8()?;
         let dict_size = decode_dict_size(dict_size_byte)?;
 
-        Ok(LZIPHeader { version, dict_size })
+        Ok(LzipHeader { version, dict_size })
     }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct LZIPTrailer {
+pub(crate) struct LzipTrailer {
     crc32: u32,
     data_size: u64,
     member_size: u64,
 }
 
-impl LZIPTrailer {
+impl LzipTrailer {
     fn parse<R: Read>(reader: &mut R) -> Result<Self> {
         let crc32 = reader.read_u32()?;
         let data_size = reader.read_u64()?;
         let member_size = reader.read_u64()?;
 
-        Ok(LZIPTrailer {
+        Ok(LzipTrailer {
             crc32,
             data_size,
             member_size,
@@ -177,7 +177,7 @@ fn encode_dict_size(dict_size: u32) -> Result<u8> {
 
 #[cfg(feature = "std")]
 #[derive(Debug, Clone)]
-struct LZIPMember {
+struct LzipMember {
     start_pos: u64,
     compressed_size: u64,
 }
@@ -185,7 +185,7 @@ struct LZIPMember {
 /// Scan the LZIP file to collect information about all members.
 /// This reads from the back of the file to efficiently locate member boundaries.
 #[cfg(feature = "std")]
-fn scan_members<R: Read + Seek>(mut reader: R) -> Result<(R, Vec<LZIPMember>)> {
+fn scan_members<R: Read + Seek>(mut reader: R) -> Result<(R, Vec<LzipMember>)> {
     let file_size = reader.seek(SeekFrom::End(0))?;
 
     if file_size < (HEADER_SIZE + TRAILER_SIZE) as u64 {
@@ -234,7 +234,7 @@ fn scan_members<R: Read + Seek>(mut reader: R) -> Result<(R, Vec<LZIPMember>)> {
             return Err(error_invalid_data("invalid LZIP magic bytes"));
         }
 
-        members.push(LZIPMember {
+        members.push(LzipMember {
             start_pos: member_start,
             compressed_size: member_size,
         });

--- a/src/lzip/reader.rs
+++ b/src/lzip/reader.rs
@@ -1,13 +1,13 @@
 use alloc::vec::Vec;
 
-use super::{LZIPHeader, LZIPTrailer, CRC32, HEADER_SIZE, TRAILER_SIZE};
+use super::{LzipHeader, LzipTrailer, CRC32, HEADER_SIZE, TRAILER_SIZE};
 use crate::{error_invalid_data, error_invalid_input, CountingReader, LzmaReader, Read, Result};
 
 /// A single-threaded LZIP decompressor.
 pub struct LzipReader<R> {
     inner: Option<R>,
     lzma_reader: Option<LzmaReader<CountingReader<R>>>,
-    current_header: Option<LZIPHeader>,
+    current_header: Option<LzipHeader>,
     finished: bool,
     trailer_buf: Vec<u8>,
     crc_digest: Option<crc::Digest<'static, u32, crc::Table<16>>>,
@@ -60,7 +60,7 @@ impl<R: Read> LzipReader<R> {
     fn start_next_member(&mut self) -> Result<bool> {
         let mut reader = self.inner.take().expect("inner reader not set");
 
-        let header = match LZIPHeader::parse(&mut reader) {
+        let header = match LzipHeader::parse(&mut reader) {
             Ok(header) => header,
             Err(_) => {
                 // If header parsing fails, we've probably reached EOF:
@@ -100,7 +100,7 @@ impl<R: Read> LzipReader<R> {
         let compressed_bytes = counting_reader.bytes_read();
 
         let mut inner_reader = counting_reader.inner;
-        let trailer = LZIPTrailer::parse(&mut inner_reader)?;
+        let trailer = LzipTrailer::parse(&mut inner_reader)?;
 
         let computed_crc = self.crc_digest.take().expect("no CRC digest").finalize();
 

--- a/src/lzip/reader_mt.rs
+++ b/src/lzip/reader_mt.rs
@@ -7,7 +7,7 @@ use std::{
     },
 };
 
-use super::{scan_members, LZIPMember};
+use super::{scan_members, LzipMember};
 use crate::{
     set_error,
     work_pool::{WorkPool, WorkPoolConfig, WorkPoolState},
@@ -24,7 +24,7 @@ struct WorkUnit {
 /// A multi-threaded LZIP decompressor.
 pub struct LzipReaderMt<R: Read + Seek> {
     inner: R,
-    members: Vec<LZIPMember>,
+    members: Vec<LzipMember>,
     work_pool: WorkPool<WorkUnit, Vec<u8>>,
     current_chunk: Cursor<Vec<u8>>,
 }

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -1,7 +1,7 @@
 use super::{
-    decoder::LZMADecoder,
+    decoder::LzmaDecoder,
     error_invalid_input,
-    lz::LZDecoder,
+    lz::LzDecoder,
     range_dec::{RangeDecoder, RangeDecoderBuffer},
     Read,
 };
@@ -27,9 +27,9 @@ pub const COMPRESSED_SIZE_MAX: u32 = 1 << 16;
 /// ```
 pub struct Lzma2Reader<R> {
     inner: R,
-    lz: LZDecoder,
+    lz: LzDecoder,
     rc: RangeDecoder<RangeDecoderBuffer>,
-    lzma: Option<LZMADecoder>,
+    lzma: Option<LzmaDecoder>,
     uncompressed_size: usize,
     is_lzma_chunk: bool,
     need_dict_reset: bool,
@@ -71,7 +71,7 @@ impl<R: Read> Lzma2Reader<R> {
     /// `dict_size` is the dictionary size in bytes.
     pub fn new(inner: R, dict_size: u32, preset_dict: Option<&[u8]>) -> Self {
         let has_preset = preset_dict.as_ref().map(|a| !a.is_empty()).unwrap_or(false);
-        let lz = LZDecoder::new(get_dict_size(dict_size) as _, preset_dict);
+        let lz = LzDecoder::new(get_dict_size(dict_size) as _, preset_dict);
         let rc = RangeDecoder::new_buffer(COMPRESSED_SIZE_MAX as _);
         Self {
             inner,
@@ -162,7 +162,7 @@ impl<R: Read> Lzma2Reader<R> {
         if lc + lp > 4 {
             return Err(error_invalid_input("corrupted input data (LZMA2:4)"));
         }
-        self.lzma = Some(LZMADecoder::new(lc as _, lp as _, pb as _));
+        self.lzma = Some(LzmaDecoder::new(lc as _, lp as _, pb as _));
 
         Ok(())
     }

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -1,6 +1,6 @@
 use super::{
-    decoder::LZMADecoder, error_invalid_data, error_invalid_input, error_out_of_memory,
-    lz::LZDecoder, range_dec::RangeDecoder, ByteReader, Read, DICT_SIZE_MAX,
+    decoder::LzmaDecoder, error_invalid_data, error_invalid_input, error_out_of_memory,
+    lz::LzDecoder, range_dec::RangeDecoder, ByteReader, Read, DICT_SIZE_MAX,
 };
 
 /// Calculates the memory usage in KiB required for LZMA decompression from properties byte.
@@ -58,9 +58,9 @@ fn get_dict_size(dict_size: u32) -> crate::Result<u32> {
 /// assert_eq!(out, b"Hello, world!");
 /// ```
 pub struct LzmaReader<R> {
-    lz: LZDecoder,
+    lz: LzDecoder,
     rc: RangeDecoder<R>,
-    lzma: LZMADecoder,
+    lzma: LzmaDecoder,
     end_reached: bool,
     relaxed_end_cond: bool,
     remaining_size: u64,
@@ -135,8 +135,8 @@ impl<R: Read> LzmaReader<R> {
                 return Err(e);
             }
         };
-        let lz = LZDecoder::new(get_dict_size(dict_size)? as _, preset_dict);
-        let lzma = LZMADecoder::new(lc, lp, pb);
+        let lz = LzDecoder::new(get_dict_size(dict_size)? as _, preset_dict);
+        let lzma = LzmaDecoder::new(lc, lp, pb);
         Ok(Self {
             // reader,
             lz,

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 #[derive(Debug, Copy, Clone)]
 pub enum Error {
     /// End of file reached unexpectedly.
-    EOF,
+    Eof,
     /// Operation was interrupted.
     Interrupted,
     /// Invalid data encountered.
@@ -49,7 +49,7 @@ fn default_read_exact<R: Read + ?Sized>(this: &mut R, mut buf: &mut [u8]) -> cra
     }
 
     if !buf.is_empty() {
-        Err(Error::EOF)
+        Err(Error::Eof)
     } else {
         Ok(())
     }

--- a/src/xz.rs
+++ b/src/xz.rs
@@ -102,7 +102,7 @@ impl FilterConfig {
     /// Creates a new BCJ ARM filter configuration.
     pub fn new_bcj_arm(start_pos: u32) -> Self {
         Self {
-            filter_type: FilterType::BcjARM,
+            filter_type: FilterType::BcjArm,
             property: start_pos,
         }
     }
@@ -110,7 +110,7 @@ impl FilterConfig {
     /// Creates a new BCJ ARM Thumb filter configuration.
     pub fn new_bcj_arm_thumb(start_pos: u32) -> Self {
         Self {
-            filter_type: FilterType::BcjARMThumb,
+            filter_type: FilterType::BcjArmThumb,
             property: start_pos,
         }
     }
@@ -118,7 +118,7 @@ impl FilterConfig {
     /// Creates a new BCJ ARM64 filter configuration.
     pub fn new_bcj_arm64(start_pos: u32) -> Self {
         Self {
-            filter_type: FilterType::BcjARM64,
+            filter_type: FilterType::BcjArm64,
             property: start_pos,
         }
     }
@@ -126,7 +126,7 @@ impl FilterConfig {
     /// Creates a new BCJ IA64 filter configuration.
     pub fn new_bcj_ia64(start_pos: u32) -> Self {
         Self {
-            filter_type: FilterType::BcjIA64,
+            filter_type: FilterType::BcjIa64,
             property: start_pos,
         }
     }
@@ -134,7 +134,7 @@ impl FilterConfig {
     /// Creates a new BCJ PPC filter configuration.
     pub fn new_bcj_ppc(start_pos: u32) -> Self {
         Self {
-            filter_type: FilterType::BcjPPC,
+            filter_type: FilterType::BcjPpc,
             property: start_pos,
         }
     }
@@ -142,7 +142,7 @@ impl FilterConfig {
     /// Creates a new BCJ SPARC filter configuration.
     pub fn new_bcj_sparc(start_pos: u32) -> Self {
         Self {
-            filter_type: FilterType::BcjSPARC,
+            filter_type: FilterType::BcjSparc,
             property: start_pos,
         }
     }
@@ -150,7 +150,7 @@ impl FilterConfig {
     /// Creates a new BCJ RISC-V filter configuration.
     pub fn new_bcj_risc_v(start_pos: u32) -> Self {
         Self {
-            filter_type: FilterType::BcjRISCV,
+            filter_type: FilterType::BcjRiscv,
             property: start_pos,
         }
     }
@@ -198,21 +198,21 @@ pub enum FilterType {
     /// BCJ x86 filter
     BcjX86,
     /// BCJ PowerPC filter
-    BcjPPC,
+    BcjPpc,
     /// BCJ IA64 filter
-    BcjIA64,
+    BcjIa64,
     /// BCJ ARM filter
-    BcjARM,
+    BcjArm,
     /// BCJ ARM Thumb
-    BcjARMThumb,
+    BcjArmThumb,
     /// BCJ SPARC filter
-    BcjSPARC,
+    BcjSparc,
     /// BCJ ARM64 filter
-    BcjARM64,
+    BcjArm64,
     /// BCJ RISC-V filter
-    BcjRISCV,
+    BcjRiscv,
     /// LZMA2 filter
-    LZMA2,
+    Lzma2,
 }
 
 impl TryFrom<u64> for FilterType {
@@ -222,14 +222,14 @@ impl TryFrom<u64> for FilterType {
         match value {
             0x03 => Ok(FilterType::Delta),
             0x04 => Ok(FilterType::BcjX86),
-            0x05 => Ok(FilterType::BcjPPC),
-            0x06 => Ok(FilterType::BcjIA64),
-            0x07 => Ok(FilterType::BcjARM),
-            0x08 => Ok(FilterType::BcjARMThumb),
-            0x09 => Ok(FilterType::BcjSPARC),
-            0x0A => Ok(FilterType::BcjARM64),
-            0x0B => Ok(FilterType::BcjRISCV),
-            0x21 => Ok(FilterType::LZMA2),
+            0x05 => Ok(FilterType::BcjPpc),
+            0x06 => Ok(FilterType::BcjIa64),
+            0x07 => Ok(FilterType::BcjArm),
+            0x08 => Ok(FilterType::BcjArmThumb),
+            0x09 => Ok(FilterType::BcjSparc),
+            0x0A => Ok(FilterType::BcjArm64),
+            0x0B => Ok(FilterType::BcjRiscv),
+            0x21 => Ok(FilterType::Lzma2),
             _ => Err(()),
         }
     }
@@ -412,13 +412,13 @@ impl BlockHeader {
                     (distance_prop as u32) + 1
                 }
                 FilterType::BcjX86
-                | FilterType::BcjPPC
-                | FilterType::BcjIA64
-                | FilterType::BcjARM
-                | FilterType::BcjARMThumb
-                | FilterType::BcjSPARC
-                | FilterType::BcjARM64
-                | FilterType::BcjRISCV => {
+                | FilterType::BcjPpc
+                | FilterType::BcjIa64
+                | FilterType::BcjArm
+                | FilterType::BcjArmThumb
+                | FilterType::BcjSparc
+                | FilterType::BcjArm64
+                | FilterType::BcjRiscv => {
                     if offset >= header_data.len() {
                         return Err(error_invalid_data(
                             "XZ block header too short for BCJ properties",
@@ -452,13 +452,13 @@ impl BlockHeader {
                             // Validate alignment based on filter type.
                             let bcj_alignment = match filter_type {
                                 FilterType::BcjX86 => 1,
-                                FilterType::BcjPPC => 4,
-                                FilterType::BcjIA64 => 16,
-                                FilterType::BcjARM => 4,
-                                FilterType::BcjARMThumb => 2,
-                                FilterType::BcjSPARC => 4,
-                                FilterType::BcjARM64 => 4,
-                                FilterType::BcjRISCV => 2,
+                                FilterType::BcjPpc => 4,
+                                FilterType::BcjIa64 => 16,
+                                FilterType::BcjArm => 4,
+                                FilterType::BcjArmThumb => 2,
+                                FilterType::BcjSparc => 4,
+                                FilterType::BcjArm64 => 4,
+                                FilterType::BcjRiscv => 2,
                                 _ => unreachable!(),
                             };
 
@@ -475,7 +475,7 @@ impl BlockHeader {
                         }
                     }
                 }
-                FilterType::LZMA2 => {
+                FilterType::Lzma2 => {
                     if offset >= header_data.len() {
                         return Err(error_invalid_data(
                             "XZ block header too short for LZMA2 properties",
@@ -515,7 +515,7 @@ impl BlockHeader {
             properties[i] = property;
         }
 
-        if filters.iter().filter_map(|x| *x).next_back() != Some(FilterType::LZMA2) {
+        if filters.iter().filter_map(|x| *x).next_back() != Some(FilterType::Lzma2) {
             return Err(error_invalid_input(
                 "XZ block's last filter must be a LZMA2 filter",
             ));
@@ -647,13 +647,13 @@ impl BlockHeader {
                     (distance_prop as u32) + 1
                 }
                 FilterType::BcjX86
-                | FilterType::BcjPPC
-                | FilterType::BcjIA64
-                | FilterType::BcjARM
-                | FilterType::BcjARMThumb
-                | FilterType::BcjSPARC
-                | FilterType::BcjARM64
-                | FilterType::BcjRISCV => {
+                | FilterType::BcjPpc
+                | FilterType::BcjIa64
+                | FilterType::BcjArm
+                | FilterType::BcjArmThumb
+                | FilterType::BcjSparc
+                | FilterType::BcjArm64
+                | FilterType::BcjRiscv => {
                     if offset >= header_data.len() {
                         return Err(error_invalid_data(
                             "Block header too short for BCJ properties",
@@ -684,7 +684,7 @@ impl BlockHeader {
                         _ => return Err(error_invalid_data("Invalid BCJ properties size")),
                     }
                 }
-                FilterType::LZMA2 => {
+                FilterType::Lzma2 => {
                     if offset >= header_data.len() {
                         return Err(error_invalid_data(
                             "Block header too short for LZMA2 properties",
@@ -1094,35 +1094,35 @@ fn create_filter_chain<'reader>(
                 let start_offset = property as usize;
                 Box::new(BcjReader::new_x86(chain_reader, start_offset))
             }
-            FilterType::BcjPPC => {
+            FilterType::BcjPpc => {
                 let start_offset = property as usize;
                 Box::new(BcjReader::new_ppc(chain_reader, start_offset))
             }
-            FilterType::BcjIA64 => {
+            FilterType::BcjIa64 => {
                 let start_offset = property as usize;
                 Box::new(BcjReader::new_ia64(chain_reader, start_offset))
             }
-            FilterType::BcjARM => {
+            FilterType::BcjArm => {
                 let start_offset = property as usize;
                 Box::new(BcjReader::new_arm(chain_reader, start_offset))
             }
-            FilterType::BcjARMThumb => {
+            FilterType::BcjArmThumb => {
                 let start_offset = property as usize;
                 Box::new(BcjReader::new_arm_thumb(chain_reader, start_offset))
             }
-            FilterType::BcjSPARC => {
+            FilterType::BcjSparc => {
                 let start_offset = property as usize;
                 Box::new(BcjReader::new_sparc(chain_reader, start_offset))
             }
-            FilterType::BcjARM64 => {
+            FilterType::BcjArm64 => {
                 let start_offset = property as usize;
                 Box::new(BcjReader::new_arm64(chain_reader, start_offset))
             }
-            FilterType::BcjRISCV => {
+            FilterType::BcjRiscv => {
                 let start_offset = property as usize;
                 Box::new(BcjReader::new_riscv(chain_reader, start_offset))
             }
-            FilterType::LZMA2 => {
+            FilterType::Lzma2 => {
                 let dict_size = property;
                 Box::new(Lzma2Reader::new(chain_reader, dict_size, None))
             }
@@ -1165,14 +1165,14 @@ fn generate_block_header_data(
         let filter_id = match filter_config.filter_type {
             FilterType::Delta => 0x03,
             FilterType::BcjX86 => 0x04,
-            FilterType::BcjPPC => 0x05,
-            FilterType::BcjIA64 => 0x06,
-            FilterType::BcjARM => 0x07,
-            FilterType::BcjARMThumb => 0x08,
-            FilterType::BcjSPARC => 0x09,
-            FilterType::BcjARM64 => 0x0A,
-            FilterType::BcjRISCV => 0x0B,
-            FilterType::LZMA2 => 0x21,
+            FilterType::BcjPpc => 0x05,
+            FilterType::BcjIa64 => 0x06,
+            FilterType::BcjArm => 0x07,
+            FilterType::BcjArmThumb => 0x08,
+            FilterType::BcjSparc => 0x09,
+            FilterType::BcjArm64 => 0x0A,
+            FilterType::BcjRiscv => 0x0B,
+            FilterType::Lzma2 => 0x21,
         };
         let size = encode_multibyte_integer(filter_id, &mut temp_buf)?;
         header_data.extend_from_slice(&temp_buf[..size]);
@@ -1188,13 +1188,13 @@ fn generate_block_header_data(
                 header_data.push(distance_prop);
             }
             FilterType::BcjX86
-            | FilterType::BcjPPC
-            | FilterType::BcjIA64
-            | FilterType::BcjARM
-            | FilterType::BcjARMThumb
-            | FilterType::BcjSPARC
-            | FilterType::BcjARM64
-            | FilterType::BcjRISCV => {
+            | FilterType::BcjPpc
+            | FilterType::BcjIa64
+            | FilterType::BcjArm
+            | FilterType::BcjArmThumb
+            | FilterType::BcjSparc
+            | FilterType::BcjArm64
+            | FilterType::BcjRiscv => {
                 if filter_config.property == 0 {
                     // No start offset.
                     let size = encode_multibyte_integer(0, &mut temp_buf)?;
@@ -1206,7 +1206,7 @@ fn generate_block_header_data(
                     header_data.extend_from_slice(&filter_config.property.to_le_bytes());
                 }
             }
-            FilterType::LZMA2 => {
+            FilterType::Lzma2 => {
                 let size = encode_multibyte_integer(1, &mut temp_buf)?;
                 header_data.extend_from_slice(&temp_buf[..size]);
 

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -12,7 +12,7 @@ use crate::{
 #[allow(clippy::large_enum_variant)]
 enum FilterReader<R: Read> {
     Counting(CountingReader<R>),
-    LZMA2(Lzma2Reader<Box<FilterReader<R>>>),
+    Lzma2(Lzma2Reader<Box<FilterReader<R>>>),
     Delta(DeltaReader<Box<FilterReader<R>>>),
     Bcj(BcjReader<Box<FilterReader<R>>>),
     Dummy,
@@ -22,7 +22,7 @@ impl<R: Read> Read for FilterReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self {
             FilterReader::Counting(reader) => reader.read(buf),
-            FilterReader::LZMA2(reader) => reader.read(buf),
+            FilterReader::Lzma2(reader) => reader.read(buf),
             FilterReader::Delta(reader) => reader.read(buf),
             FilterReader::Bcj(reader) => reader.read(buf),
             FilterReader::Dummy => unimplemented!(),
@@ -50,40 +50,40 @@ impl<R: Read> FilterReader<R> {
                     let start_offset = property as usize;
                     FilterReader::Bcj(BcjReader::new_x86(Box::new(chain_reader), start_offset))
                 }
-                FilterType::BcjPPC => {
+                FilterType::BcjPpc => {
                     let start_offset = property as usize;
                     FilterReader::Bcj(BcjReader::new_ppc(Box::new(chain_reader), start_offset))
                 }
-                FilterType::BcjIA64 => {
+                FilterType::BcjIa64 => {
                     let start_offset = property as usize;
                     FilterReader::Bcj(BcjReader::new_ia64(Box::new(chain_reader), start_offset))
                 }
-                FilterType::BcjARM => {
+                FilterType::BcjArm => {
                     let start_offset = property as usize;
                     FilterReader::Bcj(BcjReader::new_arm(Box::new(chain_reader), start_offset))
                 }
-                FilterType::BcjARMThumb => {
+                FilterType::BcjArmThumb => {
                     let start_offset = property as usize;
                     FilterReader::Bcj(BcjReader::new_arm_thumb(
                         Box::new(chain_reader),
                         start_offset,
                     ))
                 }
-                FilterType::BcjSPARC => {
+                FilterType::BcjSparc => {
                     let start_offset = property as usize;
                     FilterReader::Bcj(BcjReader::new_sparc(Box::new(chain_reader), start_offset))
                 }
-                FilterType::BcjARM64 => {
+                FilterType::BcjArm64 => {
                     let start_offset = property as usize;
                     FilterReader::Bcj(BcjReader::new_arm64(Box::new(chain_reader), start_offset))
                 }
-                FilterType::BcjRISCV => {
+                FilterType::BcjRiscv => {
                     let start_offset = property as usize;
                     FilterReader::Bcj(BcjReader::new_riscv(Box::new(chain_reader), start_offset))
                 }
-                FilterType::LZMA2 => {
+                FilterType::Lzma2 => {
                     let dict_size = property;
-                    FilterReader::LZMA2(Lzma2Reader::new(Box::new(chain_reader), dict_size, None))
+                    FilterReader::Lzma2(Lzma2Reader::new(Box::new(chain_reader), dict_size, None))
                 }
             };
         }
@@ -94,7 +94,7 @@ impl<R: Read> FilterReader<R> {
     fn bytes_read(&self) -> u64 {
         match self {
             FilterReader::Counting(reader) => reader.bytes_read(),
-            FilterReader::LZMA2(reader) => reader.inner().bytes_read(),
+            FilterReader::Lzma2(reader) => reader.inner().bytes_read(),
             FilterReader::Delta(reader) => reader.inner().bytes_read(),
             FilterReader::Bcj(reader) => reader.inner().bytes_read(),
             FilterReader::Dummy => unimplemented!(),
@@ -104,7 +104,7 @@ impl<R: Read> FilterReader<R> {
     fn into_inner(self) -> R {
         match self {
             FilterReader::Counting(reader) => reader.inner,
-            FilterReader::LZMA2(reader) => {
+            FilterReader::Lzma2(reader) => {
                 let filter_reader = reader.into_inner();
                 filter_reader.into_inner()
             }
@@ -123,7 +123,7 @@ impl<R: Read> FilterReader<R> {
     fn inner(&self) -> &R {
         match self {
             FilterReader::Counting(reader) => &reader.inner,
-            FilterReader::LZMA2(reader) => {
+            FilterReader::Lzma2(reader) => {
                 let filter_reader = reader.inner();
 
                 filter_reader.inner()
@@ -143,7 +143,7 @@ impl<R: Read> FilterReader<R> {
     fn inner_mut(&mut self) -> &mut R {
         match self {
             FilterReader::Counting(reader) => &mut reader.inner,
-            FilterReader::LZMA2(reader) => {
+            FilterReader::Lzma2(reader) => {
                 let filter_reader = reader.inner_mut();
                 filter_reader.inner_mut()
             }

--- a/src/xz/reader_mt.rs
+++ b/src/xz/reader_mt.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-struct XZBlock {
+struct XzBlock {
     start_pos: u64,
     unpadded_size: u64,
     uncompressed_size: u64,
@@ -45,7 +45,7 @@ enum State {
 /// A multi-threaded XZ decompressor.
 pub struct XzReaderMt<R: Read + Seek> {
     inner: Option<R>,
-    blocks: Vec<XZBlock>,
+    blocks: Vec<XzBlock>,
     check_type: CheckType,
     result_rx: Receiver<ResultUnit>,
     result_tx: SyncSender<ResultUnit>,
@@ -154,7 +154,7 @@ impl<R: Read + Seek> XzReaderMt<R> {
         let mut block_start_pos = header_end_pos;
 
         for record in &index.records {
-            self.blocks.push(XZBlock {
+            self.blocks.push(XzBlock {
                 start_pos: block_start_pos,
                 unpadded_size: record.unpadded_size,
                 uncompressed_size: record.uncompressed_size,

--- a/src/xz/writer.rs
+++ b/src/xz/writer.rs
@@ -15,7 +15,7 @@ use crate::{
 #[allow(clippy::large_enum_variant)]
 enum FilterWriter<W: Write> {
     Counting(CountingWriter<W>),
-    LZMA2(Lzma2Writer<Box<FilterWriter<W>>>),
+    Lzma2(Lzma2Writer<Box<FilterWriter<W>>>),
     Delta(DeltaWriter<Box<FilterWriter<W>>>),
     Bcj(BcjWriter<Box<FilterWriter<W>>>),
     Dummy,
@@ -25,7 +25,7 @@ impl<W: Write> Write for FilterWriter<W> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         match self {
             FilterWriter::Counting(writer) => writer.write(buf),
-            FilterWriter::LZMA2(writer) => writer.write(buf),
+            FilterWriter::Lzma2(writer) => writer.write(buf),
             FilterWriter::Delta(writer) => writer.write(buf),
             FilterWriter::Bcj(writer) => writer.write(buf),
             FilterWriter::Dummy => unimplemented!(),
@@ -35,7 +35,7 @@ impl<W: Write> Write for FilterWriter<W> {
     fn flush(&mut self) -> Result<()> {
         match self {
             FilterWriter::Counting(writer) => writer.flush(),
-            FilterWriter::LZMA2(writer) => writer.flush(),
+            FilterWriter::Lzma2(writer) => writer.flush(),
             FilterWriter::Delta(writer) => writer.flush(),
             FilterWriter::Bcj(writer) => writer.flush(),
             FilterWriter::Dummy => unimplemented!(),
@@ -61,43 +61,43 @@ impl<W: Write> FilterWriter<W> {
                     let start_offset = filter_config.property as usize;
                     FilterWriter::Bcj(BcjWriter::new_x86(Box::new(chain_writer), start_offset))
                 }
-                FilterType::BcjPPC => {
+                FilterType::BcjPpc => {
                     let start_offset = filter_config.property as usize;
                     FilterWriter::Bcj(BcjWriter::new_ppc(Box::new(chain_writer), start_offset))
                 }
-                FilterType::BcjIA64 => {
+                FilterType::BcjIa64 => {
                     let start_offset = filter_config.property as usize;
                     FilterWriter::Bcj(BcjWriter::new_ia64(Box::new(chain_writer), start_offset))
                 }
-                FilterType::BcjARM => {
+                FilterType::BcjArm => {
                     let start_offset = filter_config.property as usize;
                     FilterWriter::Bcj(BcjWriter::new_arm(Box::new(chain_writer), start_offset))
                 }
-                FilterType::BcjARMThumb => {
+                FilterType::BcjArmThumb => {
                     let start_offset = filter_config.property as usize;
                     FilterWriter::Bcj(BcjWriter::new_arm_thumb(
                         Box::new(chain_writer),
                         start_offset,
                     ))
                 }
-                FilterType::BcjSPARC => {
+                FilterType::BcjSparc => {
                     let start_offset = filter_config.property as usize;
                     FilterWriter::Bcj(BcjWriter::new_sparc(Box::new(chain_writer), start_offset))
                 }
-                FilterType::BcjARM64 => {
+                FilterType::BcjArm64 => {
                     let start_offset = filter_config.property as usize;
                     FilterWriter::Bcj(BcjWriter::new_arm64(Box::new(chain_writer), start_offset))
                 }
-                FilterType::BcjRISCV => {
+                FilterType::BcjRiscv => {
                     let start_offset = filter_config.property as usize;
                     FilterWriter::Bcj(BcjWriter::new_riscv(Box::new(chain_writer), start_offset))
                 }
-                FilterType::LZMA2 => {
+                FilterType::Lzma2 => {
                     let options = Lzma2Options {
                         lzma_options: lzma_options.clone(),
                         ..Default::default()
                     };
-                    FilterWriter::LZMA2(Lzma2Writer::new(Box::new(chain_writer), options))
+                    FilterWriter::Lzma2(Lzma2Writer::new(Box::new(chain_writer), options))
                 }
             };
         }
@@ -108,7 +108,7 @@ impl<W: Write> FilterWriter<W> {
     fn into_inner(self) -> W {
         match self {
             FilterWriter::Counting(writer) => writer.inner,
-            FilterWriter::LZMA2(writer) => {
+            FilterWriter::Lzma2(writer) => {
                 let filter_writer = writer.into_inner();
                 filter_writer.into_inner()
             }
@@ -127,7 +127,7 @@ impl<W: Write> FilterWriter<W> {
     fn inner(&self) -> &W {
         match self {
             FilterWriter::Counting(writer) => &writer.inner,
-            FilterWriter::LZMA2(writer) => {
+            FilterWriter::Lzma2(writer) => {
                 let filter_writer = writer.inner();
                 filter_writer.inner()
             }
@@ -146,7 +146,7 @@ impl<W: Write> FilterWriter<W> {
     fn inner_mut(&mut self) -> &mut W {
         match self {
             FilterWriter::Counting(writer) => &mut writer.inner,
-            FilterWriter::LZMA2(writer) => {
+            FilterWriter::Lzma2(writer) => {
                 let filter_writer = writer.inner_mut();
                 filter_writer.inner_mut()
             }
@@ -165,7 +165,7 @@ impl<W: Write> FilterWriter<W> {
     fn finish(self) -> Result<CountingWriter<W>> {
         match self {
             FilterWriter::Counting(writer) => Ok(writer),
-            FilterWriter::LZMA2(writer) => {
+            FilterWriter::Lzma2(writer) => {
                 let inner_writer = writer.finish()?;
                 inner_writer.finish()
             }
@@ -273,7 +273,7 @@ impl<W: Write> XzWriter<W> {
 
         // Last filter is always LZMA2.
         options.filters.push(FilterConfig {
-            filter_type: FilterType::LZMA2,
+            filter_type: FilterType::Lzma2,
             property: 0,
         });
 

--- a/src/xz/writer_mt.rs
+++ b/src/xz/writer_mt.rs
@@ -107,7 +107,7 @@ impl<W: Write> XzWriterMt<W> {
         // Add LZMA2 filter to the list
         let mut filters = self.options.filters.clone();
         filters.push(FilterConfig {
-            filter_type: FilterType::LZMA2,
+            filter_type: FilterType::Lzma2,
             property: 0,
         });
 


### PR DESCRIPTION
This is similar to #35. This is not a breaking change because it renames private identifiers.

| Before                    | After                     |
| ------------------------- | ------------------------- |
| `BCJFilter`               | `BcjFilter`               |
| `Error::EOF`              | `Error::Eof`              |
| `FilterReader::LZMA2`     | `FilterReader::Lzma2`     |
| `FilterType::BcjARM64`    | `FilterType::BcjArm64`    |
| `FilterType::BcjARMThumb` | `FilterType::BcjArmThumb` |
| `FilterType::BcjARM`      | `FilterType::BcjArm`      |
| `FilterType::BcjIA64`     | `FilterType::BcjIa64`     |
| `FilterType::BcjPPC`      | `FilterType::BcjPpc`      |
| `FilterType::BcjRISCV`    | `FilterType::BcjRiscv`    |
| `FilterType::BcjSPARC`    | `FilterType::BcjSparc`    |
| `FilterType::LZMA2`       | `FilterType::Lzma2`       |
| `FilterWriter::LZMA2`     | `FilterWriter::Lzma2`     |
| `LZDecoder`               | `LzDecoder`               |
| `LZEncoderData`           | `LzEncoderData`           |
| `LZEncoder`               | `LzEncoder`               |
| `LZIPHeader`              | `LzipHeader`              |
| `LZIPMember`              | `LzipMember`              |
| `LZIPTrailer`             | `LzipTrailer`             |
| `LZMACoder`               | `LzmaCoder`               |
| `LZMADecoder`             | `LzmaDecoder`             |
| `LZMAEncData`             | `LzmaEncData`             |
| `LZMAEncoderModes`        | `LzmaEncoderModes`        |
| `LZMAEncoderTrait`        | `LzmaEncoderTrait`        |
| `LZMAEncoder`             | `LzmaEncoder`             |
| `XZBlock`                 | `XzBlock`                 |