### PR TITLE
chore(cargo): Remove `homepage` field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 description = "LZMA / LZMA2 / LZIP / XZ compression ported from 'tukaani xz for java'"
 edition = "2021"
-homepage = "https://github.com/hasenbanck/lzma-rust2/"
 name = "lzma-rust2"
-repository = "https://github.com/hasenbanck/lzma-rust2/"
+repository = "https://github.com/hasenbanck/lzma-rust2"
 rust-version = "1.82"
 version = "0.13.0"
 keywords = ["lzma", "lzip", "xz"]


### PR DESCRIPTION
From <https://doc.rust-lang.org/cargo/reference/manifest.html#the-homepage-field>:

> A value should only be set for `homepage` if there is a dedicated website for the crate other than the source repository or API documentation. Do not make `homepage` redundant with either the `documentation` or `repository` values.