### PR TITLE
chore: Add `forbid(unsafe_code)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 // TODO: There is a lot of code left that only the "encode" feature uses.
 #![allow(dead_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(feature = "optimization"), forbid(unsafe_code))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Set `forbid(unsafe_code)` when the `optimization` feature is disabled.

Closes #51