### PR TITLE
Don't overflow dict size when reading LZMA2 streams

### DIFF
--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -45,6 +45,10 @@ pub fn get_memory_usage(dict_size: u32) -> u32 {
 
 #[inline]
 fn get_dict_size(dict_size: u32) -> u32 {
+    if dict_size >= (u32::MAX - 15) {
+        return u32::MAX;
+    }
+
     (dict_size + 15) & !15
 }
 


### PR DESCRIPTION
There seem to be LZMA2 compressed files out there, that use a dict size of u32::MAX. The original code tried to align to 16 bytes, but we don't need to align anymore.

I would like to remove the need for the function all together, but can't test all edge cases yet.

(And I obviously can't add a test case for this either)