### PR TITLE
fix: pin crc version to 3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ xz = ["crc", "sha2"]
 lzip = ["crc"]
 
 [dependencies]
-crc = { version = "3", optional = true }
+crc = { version = "3.2.1", optional = true }
 sha2 = { version = "0.10", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ xz = ["crc", "sha2"]
 lzip = ["crc"]
 
 [dependencies]
-crc = { version = "3.2.1", optional = true }
+crc = { version = "3.2", optional = true }
 sha2 = { version = "0.10", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Using `crc@3.0.0` or `crc@3.0.1` does not work

```sh
cargo +nighlty -Z minimal-versions update
cargo test
# break
```

Fix: fix with at least `crc@3.2.1`

CRC Versions
- [3.4.0 (2025-11-26)](https://docs.rs/crate/crc/3.4.0/target-redirect/crc/)
- [3.3.0 (2025-05-07)](https://docs.rs/crate/crc/3.3.0/target-redirect/crc/)
- [3.2.1 (2024-04-08)](https://docs.rs/crate/crc/3.2.1/target-redirect/crc/)
- [3.2.0 (2024-04-07)](https://docs.rs/crate/crc/3.2.0/target-redirect/crc/) -> yanked
- [3.1.0 (2024-03-01)](https://docs.rs/crate/crc/3.1.0/target-redirect/crc/) -> yanked
- [3.1.0-beta.2 (2024-04-02)](https://docs.rs/crate/crc/3.1.0-beta.2/target-redirect/crc/) -> yanked
- [3.1.0-beta.1 (2023-10-31)](https://docs.rs/crate/crc/3.1.0-beta.1/target-redirect/crc/) -> yanked
- [3.0.1 (2023-01-28)](https://docs.rs/crate/crc/3.0.1/target-redirect/crc/) -> not working
- [3.0.0 (2022-04-23)](https://docs.rs/crate/crc/3.0.0/target-redirect/crc/) -> not working