### PR TITLE
Add sans-I/O decoders for LZMA2 and XZ

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -18,7 +18,9 @@ jobs:
           - lzip
           - lzma
           - lzma2
+          - lzma2_stream
           - xz
+          - xz_stream
     steps:
       - uses: actions/checkout@v7
       - name: Install rust version

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,3 +34,15 @@ name = "xz"
 path = "fuzz_targets/xz.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "xz_stream"
+path = "fuzz_targets/xz_stream.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "lzma2_stream"
+path = "fuzz_targets/lzma2_stream.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/lzip.rs
+++ b/fuzz/fuzz_targets/lzip.rs
@@ -3,7 +3,6 @@
 use std::io;
 
 use libfuzzer_sys::fuzz_target;
-
 use lzma_rust2::LzipReader;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/lzma.rs
+++ b/fuzz/fuzz_targets/lzma.rs
@@ -3,7 +3,6 @@
 use std::io;
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
-
 use lzma_rust2::{LzmaOptions, LzmaReader};
 
 #[derive(Debug)]

--- a/fuzz/fuzz_targets/lzma2.rs
+++ b/fuzz/fuzz_targets/lzma2.rs
@@ -3,7 +3,6 @@
 use std::io;
 
 use libfuzzer_sys::fuzz_target;
-
 use lzma_rust2::{Lzma2Reader, LzmaOptions};
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/lzma2_stream.rs
+++ b/fuzz/fuzz_targets/lzma2_stream.rs
@@ -1,0 +1,30 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use lzma_rust2::{Action, Lzma2Stream, LzmaOptions, Status};
+
+fuzz_target!(|data: &[u8]| {
+    let mut decoder = Lzma2Stream::new(LzmaOptions::DICT_SIZE_DEFAULT);
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= data.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = match decoder.process(&data[in_pos..], &mut output_buf, action) {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+        in_pos += result.bytes_consumed;
+        if result.status == Status::StreamEnd {
+            return;
+        }
+        if result.bytes_consumed == 0 && result.bytes_produced == 0 {
+            return;
+        }
+    }
+});

--- a/fuzz/fuzz_targets/lzma2_stream.rs
+++ b/fuzz/fuzz_targets/lzma2_stream.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-
 use lzma_rust2::{Action, Lzma2Stream, LzmaOptions, Status};
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/xz.rs
+++ b/fuzz/fuzz_targets/xz.rs
@@ -3,7 +3,6 @@
 use std::io;
 
 use libfuzzer_sys::fuzz_target;
-
 use lzma_rust2::XzReader;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/xz_stream.rs
+++ b/fuzz/fuzz_targets/xz_stream.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-
 use lzma_rust2::{Action, Status, XzStream};
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/xz_stream.rs
+++ b/fuzz/fuzz_targets/xz_stream.rs
@@ -1,0 +1,30 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use lzma_rust2::{Action, Status, XzStream};
+
+fuzz_target!(|data: &[u8]| {
+    let mut decoder = XzStream::new(false);
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= data.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = match decoder.process(&data[in_pos..], &mut output_buf, action) {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+        in_pos += result.bytes_consumed;
+        if result.status == Status::StreamEnd {
+            return;
+        }
+        if result.bytes_consumed == 0 && result.bytes_produced == 0 {
+            return;
+        }
+    }
+});

--- a/src/filter/bcj.rs
+++ b/src/filter/bcj.rs
@@ -13,7 +13,7 @@ use crate::Read;
 #[cfg(feature = "encoder")]
 use crate::Write;
 
-struct BcjFilter {
+pub(crate) struct BcjFilter {
     is_encoder: bool,
     pos: usize,
     prev_mask: u32,
@@ -24,7 +24,7 @@ type FilterFn = fn(filter: &mut BcjFilter, buf: &mut [u8]) -> usize;
 
 impl BcjFilter {
     #[inline]
-    fn code(&mut self, buf: &mut [u8]) -> usize {
+    pub(crate) fn code(&mut self, buf: &mut [u8]) -> usize {
         let filter = self.filter;
         filter(self, buf)
     }

--- a/src/filter/delta.rs
+++ b/src/filter/delta.rs
@@ -11,14 +11,14 @@ const MAX_DISTANCE: usize = 256;
 const _MIN_DISTANCE: usize = 1;
 const DIS_MASK: usize = MAX_DISTANCE - 1;
 
-struct Delta {
+pub(crate) struct Delta {
     distance: usize,
     history: [u8; MAX_DISTANCE],
     pos: u8,
 }
 
 impl Delta {
-    fn new(distance: usize) -> Self {
+    pub(crate) fn new(distance: usize) -> Self {
         Self {
             distance,
             history: [0; MAX_DISTANCE],
@@ -26,7 +26,7 @@ impl Delta {
         }
     }
 
-    fn decode(&mut self, buf: &mut [u8]) {
+    pub(crate) fn decode(&mut self, buf: &mut [u8]) {
         for item in buf {
             let pos = self.pos as usize;
             let h = self.history[(self.distance.wrapping_add(pos)) & DIS_MASK];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,10 @@ pub use lzma_reader::{
     LzmaReader, get_memory_usage as lzma_get_memory_usage,
     get_memory_usage_by_props as lzma_get_memory_usage_by_props,
 };
-pub use lzma2_reader::{Lzma2Reader, get_memory_usage as lzma2_get_memory_usage};
+pub use lzma2_reader::{
+    Action, Lzma2Reader, Lzma2Stream, Status, StreamResult,
+    get_memory_usage as lzma2_get_memory_usage,
+};
 #[cfg(feature = "std")]
 pub use lzma2_reader_mt::Lzma2ReaderMt;
 #[cfg(not(feature = "std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub use xz::XzReaderMt;
 #[cfg(all(feature = "xz", feature = "encoder", feature = "std"))]
 pub use xz::XzWriterMt;
 #[cfg(feature = "xz")]
-pub use xz::{CheckType, FilterConfig, FilterType, XzReader};
+pub use xz::{CheckType, FilterConfig, FilterType, XzReader, XzStream};
 #[cfg(all(feature = "xz", feature = "encoder"))]
 pub use xz::{XzOptions, XzWriter};
 

--- a/src/lz/lz_decoder.rs
+++ b/src/lz/lz_decoder.rs
@@ -180,6 +180,38 @@ impl LzDecoder {
         Ok(())
     }
 
+    pub(crate) fn copy_uncompressed_from_slice(&mut self, data: &[u8]) -> crate::Result<()> {
+        let copy_size = (self.buf_size - self.pos).min(data.len());
+        self.buf[self.pos..self.pos + copy_size].copy_from_slice(&data[..copy_size]);
+        self.pos += copy_size;
+        if self.full < self.pos {
+            self.full = self.pos;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn available_space(&self) -> usize {
+        self.buf_size - self.pos
+    }
+
+    pub(crate) fn has_output(&self) -> bool {
+        self.pos > self.start
+    }
+
+    pub(crate) fn flush_partial(&mut self, out: &mut [u8]) -> usize {
+        let available = self.pos.saturating_sub(self.start);
+        let copy_size = available.min(out.len());
+        if copy_size > 0 {
+            out[..copy_size].copy_from_slice(&self.buf[self.start..self.start + copy_size]);
+            self.start += copy_size;
+        }
+        if self.start == self.pos && self.pos == self.buf_size {
+            self.pos = 0;
+            self.start = 0;
+        }
+        copy_size
+    }
+
     pub(crate) fn flush(&mut self, out: &mut [u8], out_off: usize) -> crate::Result<usize> {
         let copy_size = self.pos.saturating_sub(self.start);
 

--- a/src/lzip.rs
+++ b/src/lzip.rs
@@ -24,7 +24,7 @@ pub use writer_mt::LzipWriterMt;
 
 use crate::{ByteReader, Read, Result, error_invalid_data, error_invalid_input};
 
-const LZIP_MAGIC: [u8; 4] = [b'L', b'Z', b'I', b'P'];
+const LZIP_MAGIC: [u8; 4] = *b"LZIP";
 
 const LZIP_VERSION: u8 = 1;
 
@@ -227,7 +227,7 @@ fn scan_members<R: Read + Seek>(mut reader: R) -> Result<(R, Vec<LzipMember>)> {
         let mut header_buf = [0u8; 4];
         reader.read_exact(&mut header_buf)?;
 
-        if header_buf != [b'L', b'Z', b'I', b'P'] {
+        if header_buf != *b"LZIP" {
             return Err(error_invalid_data("invalid LZIP magic bytes"));
         }
 

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -372,7 +372,11 @@ impl Lzma2Stream {
 
                 Lzma2State::CompressedData { remaining } => {
                     if let Some(result) = self.process_compressed_data(
-                        input, action, &mut in_pos, out_pos, remaining,
+                        input,
+                        action,
+                        &mut in_pos,
+                        out_pos,
+                        remaining,
                     )? {
                         return Ok(result);
                     }
@@ -380,16 +384,20 @@ impl Lzma2Stream {
 
                 Lzma2State::UncompressedData { remaining } => {
                     if let Some(result) = self.process_uncompressed_data(
-                        input, action, &mut in_pos, out_pos, remaining,
+                        input,
+                        action,
+                        &mut in_pos,
+                        out_pos,
+                        remaining,
                     )? {
                         return Ok(result);
                     }
                 }
 
                 Lzma2State::ChunkHeader => {
-                    if let Some(result) = self.accumulate_chunk_header(
-                        input, action, &mut in_pos, out_pos,
-                    )? {
+                    if let Some(result) =
+                        self.accumulate_chunk_header(input, action, &mut in_pos, out_pos)?
+                    {
                         return Ok(result);
                     }
                 }
@@ -420,9 +428,7 @@ impl Lzma2Stream {
         let decoded = self.lz.get_pos() - pos_before;
         self.uncompressed_size -= decoded;
 
-        if self.uncompressed_size == 0
-            && (!self.rc.is_finished() || self.lz.has_pending())
-        {
+        if self.uncompressed_size == 0 && (!self.rc.is_finished() || self.lz.has_pending()) {
             return Err(error_invalid_input("rc not finished or lz has pending"));
         }
 
@@ -440,9 +446,7 @@ impl Lzma2Stream {
     ) -> crate::Result<Option<StreamResult>> {
         if *in_pos >= input.len() {
             if action == Action::Finish {
-                return Err(error_invalid_data(
-                    "unexpected end of LZMA2 stream",
-                ));
+                return Err(error_invalid_data("unexpected end of LZMA2 stream"));
             }
             return Ok(Some(StreamResult {
                 bytes_consumed: *in_pos,
@@ -452,8 +456,7 @@ impl Lzma2Stream {
         }
         let available = &input[*in_pos..];
         let to_copy = remaining.min(available.len());
-        self.compressed_buf
-            .extend_from_slice(&available[..to_copy]);
+        self.compressed_buf.extend_from_slice(&available[..to_copy]);
         *in_pos += to_copy;
         self.total_in += to_copy as u64;
         let new_remaining = remaining - to_copy;
@@ -479,16 +482,12 @@ impl Lzma2Stream {
     ) -> crate::Result<Option<StreamResult>> {
         let lz_space = self.lz.available_space();
         if lz_space == 0 {
-            self.state = Lzma2State::DrainUncompressed {
-                remaining,
-            };
+            self.state = Lzma2State::DrainUncompressed { remaining };
             return Ok(None);
         }
         if *in_pos >= input.len() {
             if action == Action::Finish {
-                return Err(error_invalid_data(
-                    "unexpected end of LZMA2 stream",
-                ));
+                return Err(error_invalid_data("unexpected end of LZMA2 stream"));
             }
             return Ok(Some(StreamResult {
                 bytes_consumed: *in_pos,
@@ -528,9 +527,7 @@ impl Lzma2Stream {
         if self.accum.len() < self.accum_needed {
             if *in_pos >= input.len() {
                 if action == Action::Finish {
-                    return Err(error_invalid_data(
-                        "unexpected end of LZMA2 stream",
-                    ));
+                    return Err(error_invalid_data("unexpected end of LZMA2 stream"));
                 }
                 return Ok(Some(StreamResult {
                     bytes_consumed: *in_pos,
@@ -556,16 +553,14 @@ impl Lzma2Stream {
         Ok(None)
     }
 
-
     pub(crate) fn is_draining(&self) -> bool {
-        matches!(self.state, Lzma2State::DrainOutput | Lzma2State::DrainUncompressed { .. })
+        matches!(
+            self.state,
+            Lzma2State::DrainOutput | Lzma2State::DrainUncompressed { .. }
+        )
     }
 
-    pub(crate) fn drain_with_filter(
-        &mut self,
-        output: &mut [u8],
-        out_pos: &mut usize,
-    ) -> usize {
+    pub(crate) fn drain_with_filter(&mut self, output: &mut [u8], out_pos: &mut usize) -> usize {
         if *out_pos >= output.len() {
             return 0;
         }
@@ -642,8 +637,7 @@ impl Lzma2Stream {
         self.uncompressed_size = ((control & 0x1F) as usize) << 16;
         let uncompressed_hi = u16::from_be_bytes([self.accum[1], self.accum[2]]);
         self.uncompressed_size += uncompressed_hi as usize + 1;
-        let compressed_size =
-            u16::from_be_bytes([self.accum[3], self.accum[4]]) as usize + 1;
+        let compressed_size = u16::from_be_bytes([self.accum[3], self.accum[4]]) as usize + 1;
 
         if control >= 0xC0 {
             self.need_props = false;
@@ -679,8 +673,7 @@ impl Lzma2Stream {
             return Err(error_invalid_input("corrupted input data (LZMA2:0)"));
         }
 
-        self.uncompressed_size =
-            u16::from_be_bytes([self.accum[1], self.accum[2]]) as usize + 1;
+        self.uncompressed_size = u16::from_be_bytes([self.accum[1], self.accum[2]]) as usize + 1;
 
         self.state = Lzma2State::UncompressedData {
             remaining: self.uncompressed_size,

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -1,11 +1,13 @@
+use alloc::vec::Vec;
+
 use super::{
     Read,
     decoder::LzmaDecoder,
-    error_invalid_input,
+    error_invalid_data, error_invalid_input,
     lz::LzDecoder,
     range_dec::{RangeDecoder, RangeDecoderBuffer},
 };
-use crate::ByteReader;
+use crate::{ByteReader, DICT_SIZE_MIN};
 
 pub const COMPRESSED_SIZE_MAX: u32 = 1 << 16;
 
@@ -50,6 +52,20 @@ fn get_dict_size(dict_size: u32) -> u32 {
     }
 
     (dict_size + 15) & !15
+}
+
+fn decode_lzma2_props(props: u8) -> crate::Result<LzmaDecoder> {
+    if props > (4 * 5 + 4) * 9 + 8 {
+        return Err(error_invalid_input("corrupted input data (LZMA2:3)"));
+    }
+    let pb = props / (9 * 5);
+    let remainder = props - pb * 9 * 5;
+    let lp = remainder / 9;
+    let lc = remainder - lp * 9;
+    if lc + lp > 4 {
+        return Err(error_invalid_input("corrupted input data (LZMA2:4)"));
+    }
+    Ok(LzmaDecoder::new(lc as _, lp as _, pb as _))
 }
 
 impl<R> Lzma2Reader<R> {
@@ -153,21 +169,9 @@ impl<R: Read> Lzma2Reader<R> {
         Ok(())
     }
 
-    /// Reads the next props and re-creates the state by creating a new decoder.
     fn decode_props(&mut self) -> crate::Result<()> {
         let props = self.inner.read_u8()?;
-        if props > (4 * 5 + 4) * 9 + 8 {
-            return Err(error_invalid_input("corrupted input data (LZMA2:3)"));
-        }
-        let pb = props / (9 * 5);
-        let props = props - pb * 9 * 5;
-        let lp = props / 9;
-        let lc = props - lp * 9;
-        if lc + lp > 4 {
-            return Err(error_invalid_input("corrupted input data (LZMA2:4)"));
-        }
-        self.lzma = Some(LzmaDecoder::new(lc as _, lp as _, pb as _));
-
+        self.lzma = Some(decode_lzma2_props(props)?);
         Ok(())
     }
 }
@@ -219,5 +223,469 @@ impl<R: Read> Read for Lzma2Reader<R> {
         }
 
         Ok(size)
+    }
+}
+
+// ── Sans-I/O stream types ───────────────────────────────────────────────────
+
+/// Action to perform during stream processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// Process available data without flushing.
+    Run,
+    /// Signal that no more input will be provided.
+    Finish,
+}
+
+/// Status returned by stream processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// More input or output space needed to continue.
+    Ok,
+    /// The stream has been fully processed.
+    StreamEnd,
+}
+
+/// Result of a single `process()` call.
+#[derive(Debug, Clone, Copy)]
+pub struct StreamResult {
+    /// Number of bytes consumed from the input buffer.
+    pub bytes_consumed: usize,
+    /// Number of bytes written to the output buffer.
+    pub bytes_produced: usize,
+    /// Current stream status.
+    pub status: Status,
+}
+
+#[derive(Clone, Copy)]
+enum Lzma2State {
+    ChunkHeader,
+    CompressedData { remaining: usize },
+    UncompressedData { remaining: usize },
+    DrainUncompressed { remaining: usize },
+    Decode,
+    DrainOutput,
+    Finished,
+}
+
+/// Sans-I/O LZMA2 stream decoder.
+///
+/// Decodes a raw LZMA2 byte stream (no XZ container). Call `process()` repeatedly
+/// with input/output buffers until `Status::StreamEnd` is returned.
+pub struct Lzma2Stream {
+    state: Lzma2State,
+    accum: Vec<u8>,
+    accum_needed: usize,
+    lz: LzDecoder,
+    rc: RangeDecoder<RangeDecoderBuffer>,
+    lzma: Option<LzmaDecoder>,
+    compressed_buf: Vec<u8>,
+    uncompressed_size: usize,
+    need_dict_reset: bool,
+    need_props: bool,
+    total_in: u64,
+    total_out: u64,
+}
+
+impl Lzma2Stream {
+    /// Create a new LZMA2 stream decoder with the given dictionary size.
+    pub fn new(dict_size: u32) -> Self {
+        let dict_size = get_dict_size(dict_size.max(DICT_SIZE_MIN)) as usize;
+        Self {
+            state: Lzma2State::ChunkHeader,
+            accum: Vec::with_capacity(8),
+            accum_needed: 1,
+            lz: LzDecoder::new(dict_size, None),
+            rc: RangeDecoder::new_buffer(65536),
+            lzma: None,
+            compressed_buf: Vec::new(),
+            uncompressed_size: 0,
+            need_dict_reset: true,
+            need_props: true,
+            total_in: 0,
+            total_out: 0,
+        }
+    }
+
+    /// Total bytes consumed from input across all `process()` calls.
+    pub fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    /// Total bytes produced to output across all `process()` calls.
+    pub fn total_out(&self) -> u64 {
+        self.total_out
+    }
+
+    /// Returns true if the LZMA2 stream has been fully decoded.
+    pub fn is_finished(&self) -> bool {
+        matches!(self.state, Lzma2State::Finished)
+    }
+
+    /// Returns true if there is decoded output waiting to be flushed.
+    pub fn has_output(&self) -> bool {
+        self.lz.has_output()
+    }
+
+    /// Process available LZMA2 data from `input` into `output`.
+    pub fn process(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+    ) -> crate::Result<StreamResult> {
+        self.lz.ensure_capacity()?;
+
+        let mut in_pos = 0;
+        let mut out_pos = 0;
+
+        loop {
+            match self.state {
+                Lzma2State::Finished => {
+                    return Ok(StreamResult {
+                        bytes_consumed: in_pos,
+                        bytes_produced: out_pos,
+                        status: Status::StreamEnd,
+                    });
+                }
+
+                Lzma2State::DrainOutput | Lzma2State::DrainUncompressed { .. } => {
+                    if out_pos >= output.len() {
+                        return Ok(StreamResult {
+                            bytes_consumed: in_pos,
+                            bytes_produced: out_pos,
+                            status: Status::Ok,
+                        });
+                    }
+                    if !self.flush_output(output, &mut out_pos) {
+                        return Ok(StreamResult {
+                            bytes_consumed: in_pos,
+                            bytes_produced: out_pos,
+                            status: Status::Ok,
+                        });
+                    }
+                }
+
+                Lzma2State::Decode => {
+                    self.decode_lzma()?;
+                }
+
+                Lzma2State::CompressedData { remaining } => {
+                    if let Some(result) = self.process_compressed_data(
+                        input, action, &mut in_pos, out_pos, remaining,
+                    )? {
+                        return Ok(result);
+                    }
+                }
+
+                Lzma2State::UncompressedData { remaining } => {
+                    if let Some(result) = self.process_uncompressed_data(
+                        input, action, &mut in_pos, out_pos, remaining,
+                    )? {
+                        return Ok(result);
+                    }
+                }
+
+                Lzma2State::ChunkHeader => {
+                    if let Some(result) = self.accumulate_chunk_header(
+                        input, action, &mut in_pos, out_pos,
+                    )? {
+                        return Ok(result);
+                    }
+                }
+            }
+        }
+    }
+
+    fn flush_output(&mut self, output: &mut [u8], out_pos: &mut usize) -> bool {
+        let n = self.lz.flush_partial(&mut output[*out_pos..]);
+        if n > 0 {
+            *out_pos += n;
+            self.total_out += n as u64;
+        }
+        if self.lz.has_output() {
+            return false;
+        }
+        self.finish_drain();
+        true
+    }
+
+    fn decode_lzma(&mut self) -> crate::Result<()> {
+        let pos_before = self.lz.get_pos();
+        self.lz.set_limit(self.uncompressed_size);
+        self.lzma
+            .as_mut()
+            .ok_or_else(|| error_invalid_input("corrupted input data (LZMA2:1)"))?
+            .decode(&mut self.lz, &mut self.rc)?;
+        let decoded = self.lz.get_pos() - pos_before;
+        self.uncompressed_size -= decoded;
+
+        if self.uncompressed_size == 0
+            && (!self.rc.is_finished() || self.lz.has_pending())
+        {
+            return Err(error_invalid_input("rc not finished or lz has pending"));
+        }
+
+        self.state = Lzma2State::DrainOutput;
+        Ok(())
+    }
+
+    fn process_compressed_data(
+        &mut self,
+        input: &[u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: usize,
+        remaining: usize,
+    ) -> crate::Result<Option<StreamResult>> {
+        if *in_pos >= input.len() {
+            if action == Action::Finish {
+                return Err(error_invalid_data(
+                    "unexpected end of LZMA2 stream",
+                ));
+            }
+            return Ok(Some(StreamResult {
+                bytes_consumed: *in_pos,
+                bytes_produced: out_pos,
+                status: Status::Ok,
+            }));
+        }
+        let available = &input[*in_pos..];
+        let to_copy = remaining.min(available.len());
+        self.compressed_buf
+            .extend_from_slice(&available[..to_copy]);
+        *in_pos += to_copy;
+        self.total_in += to_copy as u64;
+        let new_remaining = remaining - to_copy;
+        if new_remaining == 0 {
+            self.rc.prepare_from_slice(&self.compressed_buf)?;
+            self.compressed_buf.clear();
+            self.state = Lzma2State::Decode;
+        } else {
+            self.state = Lzma2State::CompressedData {
+                remaining: new_remaining,
+            };
+        }
+        Ok(None)
+    }
+
+    fn process_uncompressed_data(
+        &mut self,
+        input: &[u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: usize,
+        remaining: usize,
+    ) -> crate::Result<Option<StreamResult>> {
+        let lz_space = self.lz.available_space();
+        if lz_space == 0 {
+            self.state = Lzma2State::DrainUncompressed {
+                remaining,
+            };
+            return Ok(None);
+        }
+        if *in_pos >= input.len() {
+            if action == Action::Finish {
+                return Err(error_invalid_data(
+                    "unexpected end of LZMA2 stream",
+                ));
+            }
+            return Ok(Some(StreamResult {
+                bytes_consumed: *in_pos,
+                bytes_produced: out_pos,
+                status: Status::Ok,
+            }));
+        }
+        let available = &input[*in_pos..];
+        let to_copy = remaining.min(available.len()).min(lz_space);
+        self.lz
+            .copy_uncompressed_from_slice(&available[..to_copy])?;
+        *in_pos += to_copy;
+        self.total_in += to_copy as u64;
+        self.uncompressed_size -= to_copy;
+        let new_remaining = remaining - to_copy;
+        if new_remaining == 0 {
+            self.state = Lzma2State::DrainOutput;
+        } else if self.lz.available_space() == 0 {
+            self.state = Lzma2State::DrainUncompressed {
+                remaining: new_remaining,
+            };
+        } else {
+            self.state = Lzma2State::UncompressedData {
+                remaining: new_remaining,
+            };
+        }
+        Ok(None)
+    }
+
+    fn accumulate_chunk_header(
+        &mut self,
+        input: &[u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: usize,
+    ) -> crate::Result<Option<StreamResult>> {
+        if self.accum.len() < self.accum_needed {
+            if *in_pos >= input.len() {
+                if action == Action::Finish {
+                    return Err(error_invalid_data(
+                        "unexpected end of LZMA2 stream",
+                    ));
+                }
+                return Ok(Some(StreamResult {
+                    bytes_consumed: *in_pos,
+                    bytes_produced: out_pos,
+                    status: Status::Ok,
+                }));
+            }
+            let available = &input[*in_pos..];
+            let need = self.accum_needed - self.accum.len();
+            let to_copy = need.min(available.len());
+            self.accum.extend_from_slice(&available[..to_copy]);
+            *in_pos += to_copy;
+            self.total_in += to_copy as u64;
+            if self.accum.len() < self.accum_needed {
+                return Ok(Some(StreamResult {
+                    bytes_consumed: *in_pos,
+                    bytes_produced: out_pos,
+                    status: Status::Ok,
+                }));
+            }
+        }
+        self.process_chunk_header()?;
+        Ok(None)
+    }
+
+
+    pub(crate) fn is_draining(&self) -> bool {
+        matches!(self.state, Lzma2State::DrainOutput | Lzma2State::DrainUncompressed { .. })
+    }
+
+    pub(crate) fn drain_with_filter(
+        &mut self,
+        output: &mut [u8],
+        out_pos: &mut usize,
+    ) -> usize {
+        if *out_pos >= output.len() {
+            return 0;
+        }
+        let n = self.lz.flush_partial(&mut output[*out_pos..]);
+        if n > 0 {
+            *out_pos += n;
+            self.total_out += n as u64;
+        }
+        if !self.lz.has_output() {
+            self.finish_drain();
+        }
+        n
+    }
+
+    pub(crate) fn drain_to_buf(&mut self, buf: &mut Vec<u8>, limit: usize) -> usize {
+        let mut tmp = [0u8; 4096];
+        let cap = limit.min(tmp.len());
+        let n = self.lz.flush_partial(&mut tmp[..cap]);
+        if n > 0 {
+            buf.extend_from_slice(&tmp[..n]);
+            self.total_out += n as u64;
+        }
+        if !self.lz.has_output() {
+            self.finish_drain();
+        }
+        n
+    }
+
+    fn finish_drain(&mut self) {
+        match self.state {
+            Lzma2State::DrainUncompressed { remaining } => {
+                self.state = Lzma2State::UncompressedData { remaining };
+            }
+            _ if self.uncompressed_size > 0 => {
+                self.state = Lzma2State::Decode;
+            }
+            _ => {
+                self.state = Lzma2State::ChunkHeader;
+                self.accum.clear();
+                self.accum_needed = 1;
+            }
+        }
+    }
+
+    fn process_chunk_header(&mut self) -> crate::Result<()> {
+        let control = self.accum[0];
+        if control == 0x00 {
+            self.state = Lzma2State::Finished;
+            Ok(())
+        } else if control >= 0x80 {
+            self.process_compressed_chunk_header(control)
+        } else if control <= 0x02 {
+            self.process_uncompressed_chunk_header(control)
+        } else {
+            Err(error_invalid_input("corrupted input data (LZMA2:2)"))
+        }
+    }
+
+    fn process_compressed_chunk_header(&mut self, control: u8) -> crate::Result<()> {
+        let needed = if control >= 0xC0 { 6 } else { 5 };
+        if self.accum.len() < needed {
+            self.accum_needed = needed;
+            return Ok(());
+        }
+
+        if control >= 0xE0 {
+            self.need_props = true;
+            self.need_dict_reset = false;
+            self.lz.reset();
+        } else if self.need_dict_reset {
+            return Err(error_invalid_input("corrupted input data (LZMA2:0)"));
+        }
+
+        self.uncompressed_size = ((control & 0x1F) as usize) << 16;
+        let uncompressed_hi = u16::from_be_bytes([self.accum[1], self.accum[2]]);
+        self.uncompressed_size += uncompressed_hi as usize + 1;
+        let compressed_size =
+            u16::from_be_bytes([self.accum[3], self.accum[4]]) as usize + 1;
+
+        if control >= 0xC0 {
+            self.need_props = false;
+            self.lzma = Some(decode_lzma2_props(self.accum[5])?);
+        } else if self.need_props {
+            return Err(error_invalid_input("corrupted input data (LZMA2:1)"));
+        } else if control >= 0xA0 {
+            if let Some(l) = self.lzma.as_mut() {
+                l.reset();
+            }
+        }
+
+        self.compressed_buf.clear();
+        self.compressed_buf.reserve(compressed_size);
+        self.state = Lzma2State::CompressedData {
+            remaining: compressed_size,
+        };
+        self.accum.clear();
+        Ok(())
+    }
+
+    fn process_uncompressed_chunk_header(&mut self, control: u8) -> crate::Result<()> {
+        if self.accum.len() < 3 {
+            self.accum_needed = 3;
+            return Ok(());
+        }
+
+        if control == 0x01 {
+            self.need_props = true;
+            self.need_dict_reset = false;
+            self.lz.reset();
+        } else if self.need_dict_reset {
+            return Err(error_invalid_input("corrupted input data (LZMA2:0)"));
+        }
+
+        self.uncompressed_size =
+            u16::from_be_bytes([self.accum[1], self.accum[2]]) as usize + 1;
+
+        self.state = Lzma2State::UncompressedData {
+            remaining: self.uncompressed_size,
+        };
+        self.accum.clear();
+        Ok(())
     }
 }

--- a/src/range_dec.rs
+++ b/src/range_dec.rs
@@ -369,6 +369,25 @@ impl RangeDecoder<RangeDecoderBuffer> {
         reader.read_exact(&mut self.inner.buf[pos..end])
     }
 
+    pub(crate) fn prepare_from_slice(&mut self, data: &[u8]) -> crate::Result<()> {
+        if data.len() < 5 {
+            return Err(error_invalid_input("buffer len must >= 5"));
+        }
+
+        if data[0] != 0x00 {
+            return Err(error_invalid_input("first byte is 0"));
+        }
+        self.code = u32::from_be_bytes([data[1], data[2], data[3], data[4]]);
+
+        self.range = 0xFFFFFFFFu32;
+        let payload = &data[5..];
+        let len = payload.len();
+        let pos = self.inner.buf.len() - len;
+        self.inner.pos = pos;
+        self.inner.buf[pos..pos + len].copy_from_slice(payload);
+        Ok(())
+    }
+
     #[inline]
     pub(crate) fn is_finished(&self) -> bool {
         self.inner.pos == self.inner.buf.len() && self.code == 0

--- a/src/xz.rs
+++ b/src/xz.rs
@@ -12,7 +12,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::io::{self, Seek, SeekFrom};
 
-pub use reader::XzReader;
+pub use reader::{XzReader, XzStream};
 #[cfg(feature = "std")]
 pub use reader_mt::XzReaderMt;
 use sha2::Digest;

--- a/src/xz.rs
+++ b/src/xz.rs
@@ -36,7 +36,7 @@ use crate::{
 
 const XZ_MAGIC: [u8; 6] = [0xFD, b'7', b'z', b'X', b'Z', 0x00];
 
-const XZ_FOOTER_MAGIC: [u8; 2] = [b'Y', b'Z'];
+const XZ_FOOTER_MAGIC: [u8; 2] = *b"YZ";
 
 #[derive(Debug, Clone)]
 struct IndexRecord {

--- a/src/xz.rs
+++ b/src/xz.rs
@@ -730,6 +730,12 @@ impl BlockHeader {
             properties[i] = property;
         }
 
+        if filters.iter().filter_map(|x| *x).next_back() != Some(FilterType::Lzma2) {
+            return Err(error_invalid_data(
+                "XZ block's last filter must be a LZMA2 filter",
+            ));
+        }
+
         Ok((filters, properties, header_size))
     }
 }

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -437,8 +437,6 @@ impl<R: Read> Read for XzReader<R> {
     }
 }
 
-// ── Sans-I/O XZ stream ─────────────────────────────────────────────────────
-
 enum StreamFilter {
     Delta(Delta),
     Bcj(BcjFilter),
@@ -508,6 +506,13 @@ enum XzStreamState {
 ///
 /// Implements a buffer-pair API: call `process()` repeatedly with input/output
 /// buffers until `Status::StreamEnd` is returned.
+/// 
+/// # Limitations
+///
+/// A block may contain at most one non-LZMA2 filter (a single BCJ or Delta
+/// filter) preceding the terminating LZMA2 filter. Streams that chain multiple
+/// non-LZMA2 filters in a block are rejected with an error. Use the blocking
+/// [`XzReader`] to decode those.
 pub struct XzStream {
     state: XzStreamState,
     accum: Vec<u8>,
@@ -736,8 +741,12 @@ impl XzStream {
         in_pos: &mut usize,
         out_pos: &mut usize,
     ) -> Result<usize> {
+        if *out_pos >= output.len() {
+            return Ok(0);
+        }
+
         if self.filter_pos < self.filter_buf.len() - self.filter_unfiltered {
-            return self.emit_filtered_output(input, output, action, in_pos, out_pos);
+            return self.emit_filtered_output(output, out_pos);
         }
 
         if self.lzma2.as_ref().unwrap().is_draining() {
@@ -766,10 +775,7 @@ impl XzStream {
 
     fn emit_filtered_output(
         &mut self,
-        input: &[u8],
         output: &mut [u8],
-        action: Action,
-        in_pos: &mut usize,
         out_pos: &mut usize,
     ) -> Result<usize> {
         let ready_end = self.filter_buf.len() - self.filter_unfiltered;
@@ -786,21 +792,6 @@ impl XzStream {
         self.filter_pos += n;
 
         if self.filter_pos < ready_end {
-            while self.lzma2.as_ref().unwrap().is_draining() {
-                if self.drain_and_filter_lzma2() == 0 {
-                    break;
-                }
-            }
-            let should_consume = {
-                let lzma2 = self.lzma2.as_ref().unwrap();
-                *in_pos < input.len() && !lzma2.is_draining() && !lzma2.is_finished()
-            };
-            if should_consume {
-                let result = self.lzma2.as_mut().unwrap()
-                    .process(&input[*in_pos..], &mut [], action)?;
-                *in_pos += result.bytes_consumed;
-                self.total_in += result.bytes_consumed as u64;
-            }
             return Ok(0);
         }
 

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -2,15 +2,17 @@ use alloc::{boxed::Box, vec::Vec};
 
 use super::{
     BlockHeader, CheckType, ChecksumCalculator, FilterType, Index, IndexRecord, StreamFooter,
-    StreamHeader, XZ_FOOTER_MAGIC, XZ_MAGIC, count_multibyte_integer_size,
-    parse_multibyte_integer,
+    StreamHeader, XZ_FOOTER_MAGIC, XZ_MAGIC, count_multibyte_integer_size, parse_multibyte_integer,
 };
 use crate::{
-    CountingReader, Lzma2Reader, Read, Result, error_invalid_data,
-    filter::{bcj::BcjReader, delta::DeltaReader},
-    filter::{bcj::BcjFilter, delta::Delta},
-    lzma2_reader::{Action, Lzma2Stream, Status, StreamResult},
+    CountingReader, Lzma2Reader, Read, Result,
     crc::Crc32,
+    error_invalid_data,
+    filter::{
+        bcj::{BcjFilter, BcjReader},
+        delta::{Delta, DeltaReader},
+    },
+    lzma2_reader::{Action, Lzma2Stream, Status, StreamResult},
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -446,30 +448,38 @@ impl StreamFilter {
     fn from_filter_type(ft: FilterType, property: u32) -> Option<Self> {
         match ft {
             FilterType::Delta => Some(StreamFilter::Delta(Box::new(Delta::new(property as usize)))),
-            FilterType::BcjX86 => {
-                Some(StreamFilter::Bcj(BcjFilter::new_x86(property as usize, false)))
-            }
-            FilterType::BcjArm => {
-                Some(StreamFilter::Bcj(BcjFilter::new_arm(property as usize, false)))
-            }
-            FilterType::BcjArm64 => {
-                Some(StreamFilter::Bcj(BcjFilter::new_arm64(property as usize, false)))
-            }
-            FilterType::BcjArmThumb => {
-                Some(StreamFilter::Bcj(BcjFilter::new_arm_thumb(property as usize, false)))
-            }
-            FilterType::BcjPpc => {
-                Some(StreamFilter::Bcj(BcjFilter::new_power_pc(property as usize, false)))
-            }
-            FilterType::BcjSparc => {
-                Some(StreamFilter::Bcj(BcjFilter::new_sparc(property as usize, false)))
-            }
-            FilterType::BcjIa64 => {
-                Some(StreamFilter::Bcj(BcjFilter::new_ia64(property as usize, false)))
-            }
-            FilterType::BcjRiscv => {
-                Some(StreamFilter::Bcj(BcjFilter::new_riscv(property as usize, false)))
-            }
+            FilterType::BcjX86 => Some(StreamFilter::Bcj(BcjFilter::new_x86(
+                property as usize,
+                false,
+            ))),
+            FilterType::BcjArm => Some(StreamFilter::Bcj(BcjFilter::new_arm(
+                property as usize,
+                false,
+            ))),
+            FilterType::BcjArm64 => Some(StreamFilter::Bcj(BcjFilter::new_arm64(
+                property as usize,
+                false,
+            ))),
+            FilterType::BcjArmThumb => Some(StreamFilter::Bcj(BcjFilter::new_arm_thumb(
+                property as usize,
+                false,
+            ))),
+            FilterType::BcjPpc => Some(StreamFilter::Bcj(BcjFilter::new_power_pc(
+                property as usize,
+                false,
+            ))),
+            FilterType::BcjSparc => Some(StreamFilter::Bcj(BcjFilter::new_sparc(
+                property as usize,
+                false,
+            ))),
+            FilterType::BcjIa64 => Some(StreamFilter::Bcj(BcjFilter::new_ia64(
+                property as usize,
+                false,
+            ))),
+            FilterType::BcjRiscv => Some(StreamFilter::Bcj(BcjFilter::new_riscv(
+                property as usize,
+                false,
+            ))),
             FilterType::Lzma2 => None,
         }
     }
@@ -506,7 +516,7 @@ enum XzStreamState {
 ///
 /// Implements a buffer-pair API: call `process()` repeatedly with input/output
 /// buffers until `Status::StreamEnd` is returned.
-/// 
+///
 /// # Limitations
 ///
 /// A block may contain at most one non-LZMA2 filter (a single BCJ or Delta
@@ -602,7 +612,11 @@ impl XzStream {
                 XzStreamState::Lzma2Data => {
                     if self.filter.is_some() {
                         if self.process_lzma2_filtered(
-                            input, output, action, &mut in_pos, &mut out_pos,
+                            input,
+                            output,
+                            action,
+                            &mut in_pos,
+                            &mut out_pos,
                         )? == 0
                         {
                             return Ok(StreamResult {
@@ -612,7 +626,11 @@ impl XzStream {
                             });
                         }
                     } else if let Some(result) = self.process_lzma2_unfiltered(
-                        input, output, action, &mut in_pos, &mut out_pos,
+                        input,
+                        output,
+                        action,
+                        &mut in_pos,
+                        &mut out_pos,
                     )? {
                         return Ok(result);
                     }
@@ -622,8 +640,7 @@ impl XzStream {
                     if self.accum.len() < self.accum_needed {
                         if in_pos >= input.len() {
                             if action == Action::Finish {
-                                if matches!(self.state, XzStreamState::InterStreamPadding)
-                                {
+                                if matches!(self.state, XzStreamState::InterStreamPadding) {
                                     if !self.accum.is_empty() {
                                         return Err(error_invalid_data(
                                             "inter-stream padding not a multiple of 4 bytes",
@@ -632,9 +649,7 @@ impl XzStream {
                                     self.state = XzStreamState::Finished;
                                     continue;
                                 }
-                                return Err(error_invalid_data(
-                                    "unexpected end of XZ stream",
-                                ));
+                                return Err(error_invalid_data("unexpected end of XZ stream"));
                             }
                             return Ok(StreamResult {
                                 bytes_consumed: in_pos,
@@ -703,19 +718,13 @@ impl XzStream {
             return Ok(None);
         }
 
-        let result = lzma2.process(
-            &input[*in_pos..],
-            &mut output[*out_pos..],
-            action,
-        )?;
+        let result = lzma2.process(&input[*in_pos..], &mut output[*out_pos..], action)?;
         *in_pos += result.bytes_consumed;
         self.total_in += result.bytes_consumed as u64;
 
         if result.bytes_produced > 0 {
             if let Some(cs) = self.checksum.as_mut() {
-                cs.update(
-                    &output[*out_pos..*out_pos + result.bytes_produced],
-                );
+                cs.update(&output[*out_pos..*out_pos + result.bytes_produced]);
             }
             *out_pos += result.bytes_produced;
             self.total_out += result.bytes_produced as u64;
@@ -758,7 +767,10 @@ impl XzStream {
             return Ok(1);
         }
 
-        let result = self.lzma2.as_mut().unwrap()
+        let result = self
+            .lzma2
+            .as_mut()
+            .unwrap()
             .process(&input[*in_pos..], &mut [], action)?;
         *in_pos += result.bytes_consumed;
         self.total_in += result.bytes_consumed as u64;
@@ -773,11 +785,7 @@ impl XzStream {
         Ok(1)
     }
 
-    fn emit_filtered_output(
-        &mut self,
-        output: &mut [u8],
-        out_pos: &mut usize,
-    ) -> Result<usize> {
+    fn emit_filtered_output(&mut self, output: &mut [u8], out_pos: &mut usize) -> Result<usize> {
         let ready_end = self.filter_buf.len() - self.filter_unfiltered;
         let available = ready_end - self.filter_pos;
         let space = output.len() - *out_pos;
@@ -853,8 +861,7 @@ impl XzStream {
         self.block_compressed_size = lzma2.total_in();
         self.block_uncompressed_size = lzma2.total_out();
 
-        let pad_needed =
-            ((4 - (self.block_compressed_size % 4)) % 4) as usize;
+        let pad_needed = ((4 - (self.block_compressed_size % 4)) % 4) as usize;
         if pad_needed > 0 {
             self.state = XzStreamState::BlockPadding;
             self.accum.clear();
@@ -881,9 +888,7 @@ impl XzStream {
         let check_size = self.check_type.checksum_size();
         self.checksum.take();
         self.index_records.push(IndexRecord {
-            unpadded_size: self.block_header_size
-                + self.block_compressed_size
-                + check_size,
+            unpadded_size: self.block_header_size + self.block_compressed_size + check_size,
             uncompressed_size: self.block_uncompressed_size,
         });
     }
@@ -896,9 +901,7 @@ impl XzStream {
                 self.process_block_header_body(header_size)
             }
             XzStreamState::BlockPadding => self.process_block_padding(),
-            XzStreamState::BlockChecksum { remaining } => {
-                self.process_block_checksum(remaining)
-            }
+            XzStreamState::BlockChecksum { remaining } => self.process_block_checksum(remaining),
             XzStreamState::IndexCount => self.process_index_count(),
             XzStreamState::IndexRecordUnpadded { remaining } => {
                 self.process_index_record_unpadded(remaining)
@@ -922,8 +925,7 @@ impl XzStream {
             return Err(error_invalid_data("invalid XZ stream flags"));
         }
         let check_type = CheckType::from_byte(data[7])?;
-        let expected_crc =
-            u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
+        let expected_crc = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
         if expected_crc != Crc32::checksum(&data[6..8]) {
             return Err(error_invalid_data("XZ stream header CRC32 mismatch"));
         }
@@ -978,9 +980,7 @@ impl XzStream {
                 if ft == FilterType::Lzma2 {
                     lzma2_dict_size = properties[i];
                     found_lzma2 = true;
-                } else if let Some(f) =
-                    StreamFilter::from_filter_type(ft, properties[i])
-                {
+                } else if let Some(f) = StreamFilter::from_filter_type(ft, properties[i]) {
                     // TODO: Support multiple filters for sans-I/O API.
                     if pre_filter.is_some() {
                         return Err(error_invalid_data(
@@ -1069,7 +1069,9 @@ impl XzStream {
 
         self.accum.clear();
         if num_records > 0 {
-            self.state = XzStreamState::IndexRecordUnpadded { remaining: num_records };
+            self.state = XzStreamState::IndexRecordUnpadded {
+                remaining: num_records,
+            };
             self.accum_needed = 1;
         } else {
             self.state = XzStreamState::IndexPaddingCrc;
@@ -1168,8 +1170,7 @@ impl XzStream {
             return Ok(());
         }
 
-        let expected_crc =
-            u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        let expected_crc = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
         let actual_crc = Crc32::checksum(&data[4..10]);
         if expected_crc != actual_crc {
             return Err(error_invalid_data("stream footer CRC32 mismatch"));
@@ -1184,9 +1185,7 @@ impl XzStream {
         }
         let footer_check_type = CheckType::from_byte(data[9])?;
         if footer_check_type != self.check_type {
-            return Err(error_invalid_data(
-                "stream footer flags don't match header",
-            ));
+            return Err(error_invalid_data("stream footer flags don't match header"));
         }
 
         if self.allow_multiple_streams {
@@ -1207,9 +1206,7 @@ impl XzStream {
         if self.accum[..4] == [0, 0, 0, 0] {
             self.accum.clear();
             self.accum_needed = 4;
-        } else if self.accum[..6.min(self.accum.len())]
-            == XZ_MAGIC[..self.accum.len().min(6)]
-        {
+        } else if self.accum[..6.min(self.accum.len())] == XZ_MAGIC[..self.accum.len().min(6)] {
             if self.accum.len() >= 6 && self.accum[..6] == XZ_MAGIC {
                 self.state = XzStreamState::StreamHeader;
                 self.accum_needed = 12;
@@ -1221,8 +1218,6 @@ impl XzStream {
         }
         Ok(())
     }
-
-
 }
 
 fn has_complete_vli(data: &[u8]) -> Result<bool> {

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -1,11 +1,16 @@
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 
 use super::{
-    BlockHeader, ChecksumCalculator, FilterType, Index, StreamFooter, StreamHeader, XZ_MAGIC,
+    BlockHeader, CheckType, ChecksumCalculator, FilterType, Index, IndexRecord, StreamFooter,
+    StreamHeader, XZ_FOOTER_MAGIC, XZ_MAGIC, count_multibyte_integer_size,
+    parse_multibyte_integer,
 };
 use crate::{
     CountingReader, Lzma2Reader, Read, Result, error_invalid_data,
     filter::{bcj::BcjReader, delta::DeltaReader},
+    filter::{bcj::BcjFilter, delta::Delta},
+    lzma2_reader::{Action, Lzma2Stream, Status, StreamResult},
+    crc::Crc32,
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -430,4 +435,813 @@ impl<R: Read> Read for XzReader<R> {
             }
         }
     }
+}
+
+// ── Sans-I/O XZ stream ─────────────────────────────────────────────────────
+
+enum StreamFilter {
+    Delta(Delta),
+    Bcj(BcjFilter),
+}
+
+impl StreamFilter {
+    fn from_filter_type(ft: FilterType, property: u32) -> Option<Self> {
+        match ft {
+            FilterType::Delta => Some(StreamFilter::Delta(Delta::new(property as usize))),
+            FilterType::BcjX86 => {
+                Some(StreamFilter::Bcj(BcjFilter::new_x86(property as usize, false)))
+            }
+            FilterType::BcjArm => {
+                Some(StreamFilter::Bcj(BcjFilter::new_arm(property as usize, false)))
+            }
+            FilterType::BcjArm64 => {
+                Some(StreamFilter::Bcj(BcjFilter::new_arm64(property as usize, false)))
+            }
+            FilterType::BcjArmThumb => {
+                Some(StreamFilter::Bcj(BcjFilter::new_arm_thumb(property as usize, false)))
+            }
+            FilterType::BcjPpc => {
+                Some(StreamFilter::Bcj(BcjFilter::new_power_pc(property as usize, false)))
+            }
+            FilterType::BcjSparc => {
+                Some(StreamFilter::Bcj(BcjFilter::new_sparc(property as usize, false)))
+            }
+            FilterType::BcjIa64 => {
+                Some(StreamFilter::Bcj(BcjFilter::new_ia64(property as usize, false)))
+            }
+            FilterType::BcjRiscv => {
+                Some(StreamFilter::Bcj(BcjFilter::new_riscv(property as usize, false)))
+            }
+            FilterType::Lzma2 => None,
+        }
+    }
+
+    fn apply_decode(&mut self, buf: &mut [u8]) -> usize {
+        match self {
+            StreamFilter::Delta(d) => {
+                d.decode(buf);
+                buf.len()
+            }
+            StreamFilter::Bcj(b) => b.code(buf),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum XzStreamState {
+    StreamHeader,
+    BlockHeaderSize,
+    BlockHeaderBody { header_size: usize },
+    Lzma2Data,
+    BlockPadding,
+    BlockChecksum { remaining: usize },
+    IndexCount,
+    IndexRecordUnpadded { remaining: u64 },
+    IndexRecordUncompressed { remaining: u64 },
+    IndexPaddingCrc,
+    StreamFooter,
+    InterStreamPadding,
+    Finished,
+}
+
+/// Sans-I/O XZ stream decoder.
+///
+/// Implements a buffer-pair API: call `process()` repeatedly with input/output
+/// buffers until `Status::StreamEnd` is returned.
+pub struct XzStream {
+    state: XzStreamState,
+    accum: Vec<u8>,
+    accum_needed: usize,
+    lzma2: Option<Lzma2Stream>,
+    checksum: Option<ChecksumCalculator>,
+    check_type: CheckType,
+    block_count: usize,
+    block_header_size: u64,
+    block_compressed_size: u64,
+    block_uncompressed_size: u64,
+    index_records: Vec<IndexRecord>,
+    index_crc: Crc32,
+    index_size: usize,
+    allow_multiple_streams: bool,
+    total_in: u64,
+    total_out: u64,
+    filter: Option<StreamFilter>,
+    filter_buf: Vec<u8>,
+    filter_pos: usize,
+    filter_unfiltered: usize,
+}
+
+impl XzStream {
+    /// Create a new XZ stream decoder.
+    ///
+    /// If `allow_multiple_streams` is true, concatenated XZ streams are decoded
+    /// sequentially until EOF.
+    pub fn new(allow_multiple_streams: bool) -> Self {
+        Self {
+            state: XzStreamState::StreamHeader,
+            accum: Vec::with_capacity(1024),
+            accum_needed: 12,
+            lzma2: None,
+            checksum: None,
+            check_type: CheckType::None,
+            block_count: 0,
+            block_header_size: 0,
+            block_compressed_size: 0,
+            block_uncompressed_size: 0,
+            index_records: Vec::new(),
+            index_crc: Crc32::new(),
+            index_size: 0,
+            allow_multiple_streams,
+            total_in: 0,
+            total_out: 0,
+            filter: None,
+            filter_buf: Vec::new(),
+            filter_pos: 0,
+            filter_unfiltered: 0,
+        }
+    }
+
+    /// Total bytes consumed from input across all `process()` calls.
+    pub fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    /// Total bytes produced to output across all `process()` calls.
+    pub fn total_out(&self) -> u64 {
+        self.total_out
+    }
+
+    /// Process available data from `input` into `output`.
+    ///
+    /// Returns how many bytes were consumed/produced and the stream status.
+    /// Call repeatedly until `Status::StreamEnd` is returned.
+    pub fn process(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+    ) -> Result<StreamResult> {
+        let mut in_pos = 0;
+        let mut out_pos = 0;
+
+        loop {
+            match &self.state {
+                XzStreamState::Finished => {
+                    return Ok(StreamResult {
+                        bytes_consumed: in_pos,
+                        bytes_produced: out_pos,
+                        status: Status::StreamEnd,
+                    });
+                }
+
+                XzStreamState::Lzma2Data => {
+                    if self.filter.is_some() {
+                        if self.process_lzma2_filtered(
+                            input, output, action, &mut in_pos, &mut out_pos,
+                        )? == 0
+                        {
+                            return Ok(StreamResult {
+                                bytes_consumed: in_pos,
+                                bytes_produced: out_pos,
+                                status: Status::Ok,
+                            });
+                        }
+                    } else if let Some(result) = self.process_lzma2_unfiltered(
+                        input, output, action, &mut in_pos, &mut out_pos,
+                    )? {
+                        return Ok(result);
+                    }
+                }
+
+                _ => {
+                    if self.accum.len() < self.accum_needed {
+                        if in_pos >= input.len() {
+                            if action == Action::Finish {
+                                if matches!(self.state, XzStreamState::InterStreamPadding)
+                                {
+                                    if !self.accum.is_empty() {
+                                        return Err(error_invalid_data(
+                                            "inter-stream padding not a multiple of 4 bytes",
+                                        ));
+                                    }
+                                    self.state = XzStreamState::Finished;
+                                    continue;
+                                }
+                                return Err(error_invalid_data(
+                                    "unexpected end of XZ stream",
+                                ));
+                            }
+                            return Ok(StreamResult {
+                                bytes_consumed: in_pos,
+                                bytes_produced: out_pos,
+                                status: Status::Ok,
+                            });
+                        }
+                        let available = &input[in_pos..];
+                        let need = self.accum_needed - self.accum.len();
+                        let to_copy = need.min(available.len());
+                        self.accum.extend_from_slice(&available[..to_copy]);
+                        in_pos += to_copy;
+                        self.total_in += to_copy as u64;
+                        if self.accum.len() < self.accum_needed {
+                            return Ok(StreamResult {
+                                bytes_consumed: in_pos,
+                                bytes_produced: out_pos,
+                                status: Status::Ok,
+                            });
+                        }
+                    }
+
+                    self.process_accumulated()?;
+                }
+            }
+        }
+    }
+
+    fn process_lzma2_unfiltered(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: &mut usize,
+    ) -> Result<Option<StreamResult>> {
+        let lzma2 = self.lzma2.as_mut().unwrap();
+
+        if lzma2.is_draining() {
+            if *out_pos >= output.len() {
+                return Ok(Some(StreamResult {
+                    bytes_consumed: *in_pos,
+                    bytes_produced: *out_pos,
+                    status: Status::Ok,
+                }));
+            }
+            let prev_out = *out_pos;
+            lzma2.drain_with_filter(output, out_pos);
+            let drained = *out_pos - prev_out;
+            if drained > 0 {
+                self.total_out += drained as u64;
+                if let Some(cs) = self.checksum.as_mut() {
+                    cs.update(&output[prev_out..*out_pos]);
+                }
+            }
+            if lzma2.has_output() {
+                return Ok(Some(StreamResult {
+                    bytes_consumed: *in_pos,
+                    bytes_produced: *out_pos,
+                    status: Status::Ok,
+                }));
+            }
+            if lzma2.is_finished() {
+                self.finish_lzma2_block()?;
+            }
+            return Ok(None);
+        }
+
+        let result = lzma2.process(
+            &input[*in_pos..],
+            &mut output[*out_pos..],
+            action,
+        )?;
+        *in_pos += result.bytes_consumed;
+        self.total_in += result.bytes_consumed as u64;
+
+        if result.bytes_produced > 0 {
+            if let Some(cs) = self.checksum.as_mut() {
+                cs.update(
+                    &output[*out_pos..*out_pos + result.bytes_produced],
+                );
+            }
+            *out_pos += result.bytes_produced;
+            self.total_out += result.bytes_produced as u64;
+        }
+
+        if result.status == Status::StreamEnd {
+            self.finish_lzma2_block()?;
+        } else if *in_pos >= input.len() || *out_pos >= output.len() {
+            return Ok(Some(StreamResult {
+                bytes_consumed: *in_pos,
+                bytes_produced: *out_pos,
+                status: Status::Ok,
+            }));
+        }
+        Ok(None)
+    }
+
+    fn process_lzma2_filtered(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: &mut usize,
+    ) -> Result<usize> {
+        if self.filter_pos < self.filter_buf.len() - self.filter_unfiltered {
+            return self.emit_filtered_output(input, output, action, in_pos, out_pos);
+        }
+
+        if self.lzma2.as_ref().unwrap().is_draining() {
+            self.drain_and_filter_lzma2();
+            let lzma2 = self.lzma2.as_ref().unwrap();
+            if !lzma2.has_output() && lzma2.is_finished() {
+                self.flush_filter_pending();
+            }
+            return Ok(1);
+        }
+
+        let result = self.lzma2.as_mut().unwrap()
+            .process(&input[*in_pos..], &mut [], action)?;
+        *in_pos += result.bytes_consumed;
+        self.total_in += result.bytes_consumed as u64;
+
+        if result.status == Status::StreamEnd {
+            return self.try_complete_filtered_block();
+        }
+
+        if *in_pos >= input.len() && !self.lzma2.as_ref().unwrap().is_draining() {
+            return Ok(0);
+        }
+        Ok(1)
+    }
+
+    fn emit_filtered_output(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: &mut usize,
+    ) -> Result<usize> {
+        let ready_end = self.filter_buf.len() - self.filter_unfiltered;
+        let available = ready_end - self.filter_pos;
+        let space = output.len() - *out_pos;
+        let n = available.min(space);
+        output[*out_pos..*out_pos + n]
+            .copy_from_slice(&self.filter_buf[self.filter_pos..self.filter_pos + n]);
+        if let Some(cs) = self.checksum.as_mut() {
+            cs.update(&output[*out_pos..*out_pos + n]);
+        }
+        *out_pos += n;
+        self.total_out += n as u64;
+        self.filter_pos += n;
+
+        if self.filter_pos < ready_end {
+            while self.lzma2.as_ref().unwrap().is_draining() {
+                if self.drain_and_filter_lzma2() == 0 {
+                    break;
+                }
+            }
+            let should_consume = {
+                let lzma2 = self.lzma2.as_ref().unwrap();
+                *in_pos < input.len() && !lzma2.is_draining() && !lzma2.is_finished()
+            };
+            if should_consume {
+                let result = self.lzma2.as_mut().unwrap()
+                    .process(&input[*in_pos..], &mut [], action)?;
+                *in_pos += result.bytes_consumed;
+                self.total_in += result.bytes_consumed as u64;
+            }
+            return Ok(0);
+        }
+
+        self.compact_filter_buf();
+
+        let is_finished = {
+            let lzma2 = self.lzma2.as_ref().unwrap();
+            !lzma2.has_output() && lzma2.is_finished()
+        };
+        if is_finished {
+            return self.try_complete_filtered_block();
+        }
+        Ok(1)
+    }
+
+    fn drain_and_filter_lzma2(&mut self) -> usize {
+        let lzma2 = self.lzma2.as_mut().unwrap();
+        let prev_len = self.filter_buf.len();
+        lzma2.drain_to_buf(&mut self.filter_buf, 4096);
+        let new_bytes = self.filter_buf.len() - prev_len;
+        if new_bytes > 0 {
+            let filter_start = prev_len - self.filter_unfiltered;
+            let filter_slice = &mut self.filter_buf[filter_start..];
+            let filtered = self.filter.as_mut().unwrap().apply_decode(filter_slice);
+            self.filter_unfiltered = filter_slice.len() - filtered;
+        }
+        new_bytes
+    }
+
+    fn compact_filter_buf(&mut self) {
+        if self.filter_unfiltered > 0 {
+            let tail_start = self.filter_buf.len() - self.filter_unfiltered;
+            let pending: Vec<u8> = self.filter_buf[tail_start..].to_vec();
+            self.filter_buf.clear();
+            self.filter_buf.extend_from_slice(&pending);
+        } else {
+            self.filter_buf.clear();
+        }
+        self.filter_pos = 0;
+        self.filter_unfiltered = self.filter_buf.len();
+    }
+
+    fn try_complete_filtered_block(&mut self) -> Result<usize> {
+        self.flush_filter_pending();
+        if self.filter_pos < self.filter_buf.len() - self.filter_unfiltered {
+            return Ok(1);
+        }
+        self.filter.take();
+        self.finish_lzma2_block()?;
+        Ok(1)
+    }
+
+    fn flush_filter_pending(&mut self) {
+        self.filter_unfiltered = 0;
+    }
+
+    fn finish_lzma2_block(&mut self) -> Result<()> {
+        let lzma2 = self.lzma2.as_ref().unwrap();
+        self.block_compressed_size = lzma2.total_in();
+        self.block_uncompressed_size = lzma2.total_out();
+
+        let pad_needed =
+            ((4 - (self.block_compressed_size % 4)) % 4) as usize;
+        if pad_needed > 0 {
+            self.state = XzStreamState::BlockPadding;
+            self.accum.clear();
+            self.accum_needed = pad_needed;
+        } else {
+            let check_size = self.check_type.checksum_size() as usize;
+            if check_size > 0 {
+                self.state = XzStreamState::BlockChecksum {
+                    remaining: check_size,
+                };
+                self.accum.clear();
+                self.accum_needed = check_size;
+            } else {
+                self.push_index_record();
+                self.state = XzStreamState::BlockHeaderSize;
+                self.accum.clear();
+                self.accum_needed = 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn push_index_record(&mut self) {
+        let check_size = self.check_type.checksum_size();
+        self.checksum.take();
+        self.index_records.push(IndexRecord {
+            unpadded_size: self.block_header_size
+                + self.block_compressed_size
+                + check_size,
+            uncompressed_size: self.block_uncompressed_size,
+        });
+    }
+
+    fn process_accumulated(&mut self) -> Result<()> {
+        match self.state {
+            XzStreamState::StreamHeader => self.process_stream_header(),
+            XzStreamState::BlockHeaderSize => self.process_block_header_size(),
+            XzStreamState::BlockHeaderBody { header_size } => {
+                self.process_block_header_body(header_size)
+            }
+            XzStreamState::BlockPadding => self.process_block_padding(),
+            XzStreamState::BlockChecksum { remaining } => {
+                self.process_block_checksum(remaining)
+            }
+            XzStreamState::IndexCount => self.process_index_count(),
+            XzStreamState::IndexRecordUnpadded { remaining } => {
+                self.process_index_record_unpadded(remaining)
+            }
+            XzStreamState::IndexRecordUncompressed { remaining } => {
+                self.process_index_record_uncompressed(remaining)
+            }
+            XzStreamState::IndexPaddingCrc => self.process_index_padding_crc(),
+            XzStreamState::StreamFooter => self.process_stream_footer(),
+            XzStreamState::InterStreamPadding => self.process_inter_stream_padding(),
+            _ => Ok(()),
+        }
+    }
+
+    fn process_stream_header(&mut self) -> Result<()> {
+        let data = &self.accum;
+        if data[..6] != XZ_MAGIC {
+            return Err(error_invalid_data("invalid XZ magic bytes"));
+        }
+        if data[6] != 0 {
+            return Err(error_invalid_data("invalid XZ stream flags"));
+        }
+        let check_type = CheckType::from_byte(data[7])?;
+        let expected_crc =
+            u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
+        if expected_crc != Crc32::checksum(&data[6..8]) {
+            return Err(error_invalid_data("XZ stream header CRC32 mismatch"));
+        }
+        self.check_type = check_type;
+        self.index_records.clear();
+        self.block_count = 0;
+        self.state = XzStreamState::BlockHeaderSize;
+        self.accum.clear();
+        self.accum_needed = 1;
+        Ok(())
+    }
+
+    fn process_block_header_size(&mut self) -> Result<()> {
+        let byte = self.accum[0];
+        if byte == 0x00 {
+            self.state = XzStreamState::IndexCount;
+            self.index_crc = Crc32::new();
+            self.index_crc.update(&[0x00]);
+            self.index_size = 0;
+            self.accum.clear();
+            self.accum_needed = 1;
+        } else {
+            let header_size = (byte as usize + 1) * 4;
+            self.state = XzStreamState::BlockHeaderBody { header_size };
+            self.accum_needed = header_size;
+        }
+        Ok(())
+    }
+
+    fn process_block_header_body(&mut self, header_size: usize) -> Result<()> {
+        let data = &self.accum[..header_size];
+
+        let crc_offset = header_size - 4;
+        let expected_crc = u32::from_le_bytes([
+            data[crc_offset],
+            data[crc_offset + 1],
+            data[crc_offset + 2],
+            data[crc_offset + 3],
+        ]);
+        let actual_crc = Crc32::checksum(&data[..crc_offset]);
+        if expected_crc != actual_crc {
+            return Err(error_invalid_data("block header CRC32 mismatch"));
+        }
+
+        let (filters, properties, _) = BlockHeader::parse_from_slice(data)?;
+
+        let mut lzma2_dict_size = 0u32;
+        let mut found_lzma2 = false;
+        let mut pre_filter: Option<StreamFilter> = None;
+        for i in 0..4 {
+            if let Some(ft) = filters[i] {
+                if ft == FilterType::Lzma2 {
+                    lzma2_dict_size = properties[i];
+                    found_lzma2 = true;
+                } else if let Some(f) =
+                    StreamFilter::from_filter_type(ft, properties[i])
+                {
+                    // TODO: Support multiple filters for sans-I/O API.
+                    if pre_filter.is_some() {
+                        return Err(error_invalid_data(
+                            "multiple non-LZMA2 filters not supported yet for stream API",
+                        ));
+                    }
+                    pre_filter = Some(f);
+                }
+            }
+        }
+        if !found_lzma2 {
+            return Err(error_invalid_data("no LZMA2 filter in block"));
+        }
+
+        self.lzma2 = Some(Lzma2Stream::new(lzma2_dict_size));
+        self.checksum = Some(ChecksumCalculator::new(self.check_type));
+        self.filter = pre_filter;
+        self.filter_buf.clear();
+        self.filter_pos = 0;
+        self.filter_unfiltered = 0;
+        self.block_count += 1;
+        self.block_header_size = header_size as u64;
+        self.block_compressed_size = 0;
+        self.block_uncompressed_size = 0;
+
+        self.state = XzStreamState::Lzma2Data;
+        self.accum.clear();
+        Ok(())
+    }
+
+    fn process_block_padding(&mut self) -> Result<()> {
+        for &b in self.accum.iter() {
+            if b != 0 {
+                return Err(error_invalid_data("non-zero block padding"));
+            }
+        }
+
+        let check_size = self.check_type.checksum_size() as usize;
+        if check_size > 0 {
+            self.state = XzStreamState::BlockChecksum {
+                remaining: check_size,
+            };
+            self.accum.clear();
+            self.accum_needed = check_size;
+        } else {
+            self.push_index_record();
+            self.state = XzStreamState::BlockHeaderSize;
+            self.accum.clear();
+            self.accum_needed = 1;
+        }
+        Ok(())
+    }
+
+    fn process_block_checksum(&mut self, remaining: usize) -> Result<()> {
+        if self.accum.len() < remaining {
+            self.accum_needed = remaining;
+            return Ok(());
+        }
+        if let Some(checksum) = self.checksum.take() {
+            if !checksum.verify(&self.accum[..remaining]) {
+                return Err(error_invalid_data("block checksum mismatch"));
+            }
+        }
+        self.push_index_record();
+        self.state = XzStreamState::BlockHeaderSize;
+        self.accum.clear();
+        self.accum_needed = 1;
+        Ok(())
+    }
+
+    fn process_index_count(&mut self) -> Result<()> {
+        if !has_complete_vli(&self.accum)? {
+            self.accum_needed = self.accum.len() + 1;
+            return Ok(());
+        }
+        let num_records = parse_multibyte_integer(&self.accum)?;
+        let vli_size = count_multibyte_integer_size(&self.accum);
+        self.index_crc.update(&self.accum[..vli_size]);
+        self.index_size += vli_size;
+
+        if num_records != self.block_count as u64 {
+            return Err(error_invalid_data(
+                "index record count does not match number of blocks",
+            ));
+        }
+
+        self.accum.clear();
+        if num_records > 0 {
+            self.state = XzStreamState::IndexRecordUnpadded { remaining: num_records };
+            self.accum_needed = 1;
+        } else {
+            self.state = XzStreamState::IndexPaddingCrc;
+            let pad_needed = (4 - ((1 + self.index_size) % 4)) % 4;
+            self.accum_needed = pad_needed + 4;
+        }
+        Ok(())
+    }
+
+    fn process_index_record_unpadded(&mut self, remaining: u64) -> Result<()> {
+        if !has_complete_vli(&self.accum)? {
+            self.accum_needed = self.accum.len() + 1;
+            return Ok(());
+        }
+        let unpadded = parse_multibyte_integer(&self.accum)?;
+        let vli_size = count_multibyte_integer_size(&self.accum);
+        self.index_crc.update(&self.accum[..vli_size]);
+        self.index_size += vli_size;
+
+        let idx = self.block_count - remaining as usize;
+        if self.index_records[idx].unpadded_size != unpadded {
+            return Err(error_invalid_data("index unpadded size mismatch"));
+        }
+
+        self.accum.clear();
+        self.state = XzStreamState::IndexRecordUncompressed { remaining };
+        self.accum_needed = 1;
+        Ok(())
+    }
+
+    fn process_index_record_uncompressed(&mut self, remaining: u64) -> Result<()> {
+        if !has_complete_vli(&self.accum)? {
+            self.accum_needed = self.accum.len() + 1;
+            return Ok(());
+        }
+        let uncompressed = parse_multibyte_integer(&self.accum)?;
+        let vli_size = count_multibyte_integer_size(&self.accum);
+        self.index_crc.update(&self.accum[..vli_size]);
+        self.index_size += vli_size;
+
+        let idx = self.block_count - remaining as usize;
+        if self.index_records[idx].uncompressed_size != uncompressed {
+            return Err(error_invalid_data("index uncompressed size mismatch"));
+        }
+
+        self.accum.clear();
+        let remaining = remaining - 1;
+        if remaining > 0 {
+            self.state = XzStreamState::IndexRecordUnpadded { remaining };
+            self.accum_needed = 1;
+        } else {
+            self.state = XzStreamState::IndexPaddingCrc;
+            let pad_needed = (4 - ((1 + self.index_size) % 4)) % 4;
+            self.accum_needed = pad_needed + 4;
+        }
+        Ok(())
+    }
+
+    fn process_index_padding_crc(&mut self) -> Result<()> {
+        let pad_needed = (4 - ((1 + self.index_size) % 4)) % 4;
+        let total_needed = pad_needed + 4;
+        if self.accum.len() < total_needed {
+            self.accum_needed = total_needed;
+            return Ok(());
+        }
+
+        for &b in &self.accum[..pad_needed] {
+            if b != 0 {
+                return Err(error_invalid_data("non-zero index padding"));
+            }
+        }
+        self.index_crc.update(&self.accum[..pad_needed]);
+
+        let expected_crc = u32::from_le_bytes([
+            self.accum[pad_needed],
+            self.accum[pad_needed + 1],
+            self.accum[pad_needed + 2],
+            self.accum[pad_needed + 3],
+        ]);
+
+        let actual_crc = core::mem::replace(&mut self.index_crc, Crc32::new()).finalize();
+        if actual_crc != expected_crc {
+            return Err(error_invalid_data("index CRC32 mismatch"));
+        }
+
+        self.accum.clear();
+        self.accum_needed = 12;
+        self.state = XzStreamState::StreamFooter;
+        Ok(())
+    }
+
+    fn process_stream_footer(&mut self) -> Result<()> {
+        let data = &self.accum;
+        if data.len() < 12 {
+            self.accum_needed = 12;
+            return Ok(());
+        }
+
+        let expected_crc =
+            u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        let actual_crc = Crc32::checksum(&data[4..10]);
+        if expected_crc != actual_crc {
+            return Err(error_invalid_data("stream footer CRC32 mismatch"));
+        }
+        if data[10..12] != XZ_FOOTER_MAGIC {
+            return Err(error_invalid_data("invalid XZ footer magic"));
+        }
+        if data[8] != 0 {
+            return Err(error_invalid_data(
+                "reserved stream footer flags byte is non-zero",
+            ));
+        }
+        let footer_check_type = CheckType::from_byte(data[9])?;
+        if footer_check_type != self.check_type {
+            return Err(error_invalid_data(
+                "stream footer flags don't match header",
+            ));
+        }
+
+        if self.allow_multiple_streams {
+            self.state = XzStreamState::InterStreamPadding;
+            self.accum.clear();
+            self.accum_needed = 4;
+        } else {
+            self.state = XzStreamState::Finished;
+        }
+        Ok(())
+    }
+
+    fn process_inter_stream_padding(&mut self) -> Result<()> {
+        if self.accum.len() < 4 {
+            self.accum_needed = 4;
+            return Ok(());
+        }
+        if self.accum[..4] == [0, 0, 0, 0] {
+            self.accum.clear();
+            self.accum_needed = 4;
+        } else if self.accum[..6.min(self.accum.len())]
+            == XZ_MAGIC[..self.accum.len().min(6)]
+        {
+            if self.accum.len() >= 6 && self.accum[..6] == XZ_MAGIC {
+                self.state = XzStreamState::StreamHeader;
+                self.accum_needed = 12;
+            } else {
+                self.accum_needed = 12;
+            }
+        } else {
+            return Err(error_invalid_data("invalid inter-stream padding"));
+        }
+        Ok(())
+    }
+
+
+}
+
+fn has_complete_vli(data: &[u8]) -> Result<bool> {
+    if data.len() > 9 {
+        return Err(error_invalid_data("XZ multibyte integer too long"));
+    }
+    for &byte in data {
+        if (byte & 0x80) == 0 {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -438,14 +438,14 @@ impl<R: Read> Read for XzReader<R> {
 }
 
 enum StreamFilter {
-    Delta(Delta),
+    Delta(Box<Delta>),
     Bcj(BcjFilter),
 }
 
 impl StreamFilter {
     fn from_filter_type(ft: FilterType, property: u32) -> Option<Self> {
         match ft {
-            FilterType::Delta => Some(StreamFilter::Delta(Delta::new(property as usize))),
+            FilterType::Delta => Some(StreamFilter::Delta(Box::new(Delta::new(property as usize)))),
             FilterType::BcjX86 => {
                 Some(StreamFilter::Bcj(BcjFilter::new_x86(property as usize, false)))
             }

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -1,0 +1,323 @@
+use std::io::{Read, Write};
+
+use lzma_rust2::{Action, Lzma2Options, Lzma2Stream, Lzma2Writer, Status};
+
+static EXECUTABLE: &str = "tests/data/executable.exe";
+static PG100: &str = "tests/data/pg100.txt";
+static PG6800: &str = "tests/data/pg6800.txt";
+static INPUT_HTML: &str = "tests/data/input.html";
+
+fn test_round_trip(path: &str, preset: u32) {
+    let data = std::fs::read(path).unwrap();
+
+    let opts = Lzma2Options::with_preset(preset);
+    let dict_size = opts.lzma_options.dict_size;
+    let mut writer = Lzma2Writer::new(Vec::new(), opts);
+    writer.write_all(&data).unwrap();
+    let compressed = writer.finish().unwrap();
+
+    let mut decoder = Lzma2Stream::new(dict_size);
+    let mut decompressed = Vec::new();
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&compressed[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+    assert!(decompressed == data);
+}
+
+#[test]
+fn round_trip_executable_0() { test_round_trip(EXECUTABLE, 0); }
+#[test]
+fn round_trip_executable_1() { test_round_trip(EXECUTABLE, 1); }
+#[test]
+fn round_trip_executable_2() { test_round_trip(EXECUTABLE, 2); }
+#[test]
+fn round_trip_executable_3() { test_round_trip(EXECUTABLE, 3); }
+#[test]
+fn round_trip_executable_4() { test_round_trip(EXECUTABLE, 4); }
+#[test]
+fn round_trip_executable_5() { test_round_trip(EXECUTABLE, 5); }
+#[test]
+fn round_trip_executable_6() { test_round_trip(EXECUTABLE, 6); }
+#[test]
+fn round_trip_executable_7() { test_round_trip(EXECUTABLE, 7); }
+#[test]
+fn round_trip_executable_8() { test_round_trip(EXECUTABLE, 8); }
+#[test]
+fn round_trip_executable_9() { test_round_trip(EXECUTABLE, 9); }
+
+#[test]
+fn round_trip_pg100_0() { test_round_trip(PG100, 0); }
+#[test]
+fn round_trip_pg100_1() { test_round_trip(PG100, 1); }
+#[test]
+fn round_trip_pg100_2() { test_round_trip(PG100, 2); }
+#[test]
+fn round_trip_pg100_3() { test_round_trip(PG100, 3); }
+#[test]
+fn round_trip_pg100_4() { test_round_trip(PG100, 4); }
+#[test]
+fn round_trip_pg100_5() { test_round_trip(PG100, 5); }
+#[test]
+fn round_trip_pg100_6() { test_round_trip(PG100, 6); }
+#[test]
+fn round_trip_pg100_7() { test_round_trip(PG100, 7); }
+#[test]
+fn round_trip_pg100_8() { test_round_trip(PG100, 8); }
+#[test]
+fn round_trip_pg100_9() { test_round_trip(PG100, 9); }
+
+#[test]
+fn round_trip_pg6800_0() { test_round_trip(PG6800, 0); }
+#[test]
+fn round_trip_pg6800_1() { test_round_trip(PG6800, 1); }
+#[test]
+fn round_trip_pg6800_2() { test_round_trip(PG6800, 2); }
+#[test]
+fn round_trip_pg6800_3() { test_round_trip(PG6800, 3); }
+#[test]
+fn round_trip_pg6800_4() { test_round_trip(PG6800, 4); }
+#[test]
+fn round_trip_pg6800_5() { test_round_trip(PG6800, 5); }
+#[test]
+fn round_trip_pg6800_6() { test_round_trip(PG6800, 6); }
+#[test]
+fn round_trip_pg6800_7() { test_round_trip(PG6800, 7); }
+#[test]
+fn round_trip_pg6800_8() { test_round_trip(PG6800, 8); }
+#[test]
+fn round_trip_pg6800_9() { test_round_trip(PG6800, 9); }
+
+#[test]
+fn cross_compat_with_reader() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+
+    let opts = Lzma2Options::with_preset(3);
+    let dict_size = opts.lzma_options.dict_size;
+    let mut writer = Lzma2Writer::new(Vec::new(), opts);
+    writer.write_all(&data).unwrap();
+    let compressed = writer.finish().unwrap();
+
+    let mut decoder = Lzma2Stream::new(dict_size);
+    let mut decompressed_stream = Vec::new();
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&compressed[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed_stream.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    let mut reader = lzma_rust2::Lzma2Reader::new(compressed.as_slice(), dict_size, None);
+    let mut decompressed_reader = Vec::new();
+    reader.read_to_end(&mut decompressed_reader).unwrap();
+
+    assert_eq!(decompressed_stream, decompressed_reader);
+    assert!(decompressed_stream == data);
+}
+
+#[test]
+fn zero_length_output_buffer() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+
+    let opts = Lzma2Options::with_preset(1);
+    let dict_size = opts.lzma_options.dict_size;
+    let mut writer = Lzma2Writer::new(Vec::new(), opts);
+    writer.write_all(&data).unwrap();
+    let compressed = writer.finish().unwrap();
+
+    let mut decoder = Lzma2Stream::new(dict_size);
+    let mut output_buf = [0u8; 0];
+    let result = decoder
+        .process(&compressed, &mut output_buf, Action::Run)
+        .unwrap();
+    assert_eq!(result.bytes_produced, 0);
+}
+
+#[test]
+fn error_on_corrupted_payload() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+
+    let opts = Lzma2Options::with_preset(1);
+    let dict_size = opts.lzma_options.dict_size;
+    let mut writer = Lzma2Writer::new(Vec::new(), opts);
+    writer.write_all(&data).unwrap();
+    let mut compressed = writer.finish().unwrap();
+
+    let mid = compressed.len() / 2;
+    compressed[mid] ^= 0xFF;
+
+    let mut decoder = Lzma2Stream::new(dict_size);
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    let mut errored = false;
+    for _ in 0..1000 {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        match decoder.process(&compressed[in_pos..], &mut output_buf, action) {
+            Ok(result) => {
+                in_pos += result.bytes_consumed;
+                if result.status == Status::StreamEnd {
+                    break;
+                }
+            }
+            Err(_) => {
+                errored = true;
+                break;
+            }
+        }
+    }
+    assert!(errored, "Expected error on corrupted payload");
+}
+
+#[test]
+fn process_after_stream_end() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+
+    let opts = Lzma2Options::with_preset(1);
+    let dict_size = opts.lzma_options.dict_size;
+    let mut writer = Lzma2Writer::new(Vec::new(), opts);
+    writer.write_all(&data).unwrap();
+    let compressed = writer.finish().unwrap();
+
+    let mut decoder = Lzma2Stream::new(dict_size);
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&compressed[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    let result = decoder.process(&[], &mut output_buf, Action::Finish);
+    match result {
+        Ok(r) => {
+            assert_eq!(r.bytes_consumed, 0);
+            assert_eq!(r.bytes_produced, 0);
+        }
+        Err(_) => {}
+    }
+}
+
+#[test]
+fn incomplete_chunk_produces_error() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+
+    let opts = Lzma2Options::with_preset(6);
+    let dict_size = opts.lzma_options.dict_size;
+    let mut writer = Lzma2Writer::new(Vec::new(), opts);
+    writer.write_all(&data).unwrap();
+    let compressed = writer.finish().unwrap();
+
+    let truncated = &compressed[..compressed.len() / 2];
+
+    let mut decoder = Lzma2Stream::new(dict_size);
+    let mut output_buf = [0u8; 4096];
+
+    let mut in_pos = 0;
+    let mut errored = false;
+    for _ in 0..100 {
+        let action = if in_pos >= truncated.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        match decoder.process(&truncated[in_pos..], &mut output_buf, action) {
+            Ok(result) => {
+                in_pos += result.bytes_consumed;
+                if result.status == Status::StreamEnd {
+                    break;
+                }
+            }
+            Err(_) => {
+                errored = true;
+                break;
+            }
+        }
+    }
+    assert!(errored, "Expected error on truncated LZMA2 stream");
+}
+
+/// Regression test for issue 1: uncompressed LZMA2 chunks that exceed
+/// the LZ dictionary buffer capacity must not silently drop bytes.
+/// Uses a tiny dict size (4096) to force the LZ buffer to fill mid-chunk.
+#[test]
+fn uncompressed_chunk_exceeds_dict() {
+    let data_len: usize = 8192;
+    let original: Vec<u8> = (0..data_len).map(|i| (i % 251) as u8).collect();
+
+    let mut lzma2_stream: Vec<u8> = Vec::new();
+    let mut offset = 0;
+    while offset < data_len {
+        let chunk = (data_len - offset).min(65535);
+        let control = if offset == 0 { 0x01u8 } else { 0x02u8 };
+        lzma2_stream.push(control);
+        let size_minus_one = (chunk - 1) as u16;
+        lzma2_stream.extend_from_slice(&size_minus_one.to_be_bytes());
+        lzma2_stream.extend_from_slice(&original[offset..offset + chunk]);
+        offset += chunk;
+    }
+    lzma2_stream.push(0x00);
+
+    let dict_size: u32 = 4096;
+    let mut decoder = Lzma2Stream::new(dict_size);
+    let mut decompressed = Vec::new();
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= lzma2_stream.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&lzma2_stream[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+    assert_eq!(decompressed.len(), original.len());
+    assert_eq!(decompressed, original);
+}

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -40,67 +40,127 @@ fn test_round_trip(path: &str, preset: u32) {
 }
 
 #[test]
-fn round_trip_executable_0() { test_round_trip(EXECUTABLE, 0); }
+fn round_trip_executable_0() {
+    test_round_trip(EXECUTABLE, 0);
+}
 #[test]
-fn round_trip_executable_1() { test_round_trip(EXECUTABLE, 1); }
+fn round_trip_executable_1() {
+    test_round_trip(EXECUTABLE, 1);
+}
 #[test]
-fn round_trip_executable_2() { test_round_trip(EXECUTABLE, 2); }
+fn round_trip_executable_2() {
+    test_round_trip(EXECUTABLE, 2);
+}
 #[test]
-fn round_trip_executable_3() { test_round_trip(EXECUTABLE, 3); }
+fn round_trip_executable_3() {
+    test_round_trip(EXECUTABLE, 3);
+}
 #[test]
-fn round_trip_executable_4() { test_round_trip(EXECUTABLE, 4); }
+fn round_trip_executable_4() {
+    test_round_trip(EXECUTABLE, 4);
+}
 #[test]
-fn round_trip_executable_5() { test_round_trip(EXECUTABLE, 5); }
+fn round_trip_executable_5() {
+    test_round_trip(EXECUTABLE, 5);
+}
 #[test]
-fn round_trip_executable_6() { test_round_trip(EXECUTABLE, 6); }
+fn round_trip_executable_6() {
+    test_round_trip(EXECUTABLE, 6);
+}
 #[test]
-fn round_trip_executable_7() { test_round_trip(EXECUTABLE, 7); }
+fn round_trip_executable_7() {
+    test_round_trip(EXECUTABLE, 7);
+}
 #[test]
-fn round_trip_executable_8() { test_round_trip(EXECUTABLE, 8); }
+fn round_trip_executable_8() {
+    test_round_trip(EXECUTABLE, 8);
+}
 #[test]
-fn round_trip_executable_9() { test_round_trip(EXECUTABLE, 9); }
+fn round_trip_executable_9() {
+    test_round_trip(EXECUTABLE, 9);
+}
 
 #[test]
-fn round_trip_pg100_0() { test_round_trip(PG100, 0); }
+fn round_trip_pg100_0() {
+    test_round_trip(PG100, 0);
+}
 #[test]
-fn round_trip_pg100_1() { test_round_trip(PG100, 1); }
+fn round_trip_pg100_1() {
+    test_round_trip(PG100, 1);
+}
 #[test]
-fn round_trip_pg100_2() { test_round_trip(PG100, 2); }
+fn round_trip_pg100_2() {
+    test_round_trip(PG100, 2);
+}
 #[test]
-fn round_trip_pg100_3() { test_round_trip(PG100, 3); }
+fn round_trip_pg100_3() {
+    test_round_trip(PG100, 3);
+}
 #[test]
-fn round_trip_pg100_4() { test_round_trip(PG100, 4); }
+fn round_trip_pg100_4() {
+    test_round_trip(PG100, 4);
+}
 #[test]
-fn round_trip_pg100_5() { test_round_trip(PG100, 5); }
+fn round_trip_pg100_5() {
+    test_round_trip(PG100, 5);
+}
 #[test]
-fn round_trip_pg100_6() { test_round_trip(PG100, 6); }
+fn round_trip_pg100_6() {
+    test_round_trip(PG100, 6);
+}
 #[test]
-fn round_trip_pg100_7() { test_round_trip(PG100, 7); }
+fn round_trip_pg100_7() {
+    test_round_trip(PG100, 7);
+}
 #[test]
-fn round_trip_pg100_8() { test_round_trip(PG100, 8); }
+fn round_trip_pg100_8() {
+    test_round_trip(PG100, 8);
+}
 #[test]
-fn round_trip_pg100_9() { test_round_trip(PG100, 9); }
+fn round_trip_pg100_9() {
+    test_round_trip(PG100, 9);
+}
 
 #[test]
-fn round_trip_pg6800_0() { test_round_trip(PG6800, 0); }
+fn round_trip_pg6800_0() {
+    test_round_trip(PG6800, 0);
+}
 #[test]
-fn round_trip_pg6800_1() { test_round_trip(PG6800, 1); }
+fn round_trip_pg6800_1() {
+    test_round_trip(PG6800, 1);
+}
 #[test]
-fn round_trip_pg6800_2() { test_round_trip(PG6800, 2); }
+fn round_trip_pg6800_2() {
+    test_round_trip(PG6800, 2);
+}
 #[test]
-fn round_trip_pg6800_3() { test_round_trip(PG6800, 3); }
+fn round_trip_pg6800_3() {
+    test_round_trip(PG6800, 3);
+}
 #[test]
-fn round_trip_pg6800_4() { test_round_trip(PG6800, 4); }
+fn round_trip_pg6800_4() {
+    test_round_trip(PG6800, 4);
+}
 #[test]
-fn round_trip_pg6800_5() { test_round_trip(PG6800, 5); }
+fn round_trip_pg6800_5() {
+    test_round_trip(PG6800, 5);
+}
 #[test]
-fn round_trip_pg6800_6() { test_round_trip(PG6800, 6); }
+fn round_trip_pg6800_6() {
+    test_round_trip(PG6800, 6);
+}
 #[test]
-fn round_trip_pg6800_7() { test_round_trip(PG6800, 7); }
+fn round_trip_pg6800_7() {
+    test_round_trip(PG6800, 7);
+}
 #[test]
-fn round_trip_pg6800_8() { test_round_trip(PG6800, 8); }
+fn round_trip_pg6800_8() {
+    test_round_trip(PG6800, 8);
+}
 #[test]
-fn round_trip_pg6800_9() { test_round_trip(PG6800, 9); }
+fn round_trip_pg6800_9() {
+    test_round_trip(PG6800, 9);
+}
 
 #[test]
 fn cross_compat_with_reader() {

--- a/tests/xz_stream.rs
+++ b/tests/xz_stream.rs
@@ -1,0 +1,467 @@
+use std::io::{Read, Write};
+
+use lzma_rust2::{Action, Status, XzOptions, XzStream, XzWriter};
+
+static EXECUTABLE: &str = "tests/data/executable.exe";
+static PG100: &str = "tests/data/pg100.txt";
+static PG6800: &str = "tests/data/pg6800.txt";
+static INPUT_HTML: &str = "tests/data/input.html";
+
+fn encode_xz(data: &[u8], preset: u32) -> Vec<u8> {
+    let options = XzOptions::with_preset(preset);
+    let mut writer = XzWriter::new(Vec::new(), options).unwrap();
+    writer.write_all(data).unwrap();
+    writer.finish().unwrap()
+}
+
+fn decode_with_stream(data: &[u8]) -> Vec<u8> {
+    let mut decoder = XzStream::new(false);
+    let mut decompressed = Vec::new();
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= data.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&data[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+    decompressed
+}
+
+fn test_round_trip(path: &str, preset: u32) {
+    let data = std::fs::read(path).unwrap();
+    let compressed = encode_xz(&data, preset);
+    let decompressed = decode_with_stream(&compressed);
+    assert!(decompressed == data);
+
+    let mut liblzma_decompressed = Vec::new();
+    {
+        use liblzma::read::XzDecoder;
+        let mut decoder = XzDecoder::new(compressed.as_slice());
+        decoder.read_to_end(&mut liblzma_decompressed).unwrap();
+    }
+    assert!(liblzma_decompressed == data);
+}
+
+#[test]
+fn round_trip_empty() {
+    let compressed = encode_xz(b"", 6);
+    let decompressed = decode_with_stream(&compressed);
+    assert!(decompressed.is_empty());
+}
+
+#[test]
+fn round_trip_executable_0() { test_round_trip(EXECUTABLE, 0); }
+#[test]
+fn round_trip_executable_1() { test_round_trip(EXECUTABLE, 1); }
+#[test]
+fn round_trip_executable_2() { test_round_trip(EXECUTABLE, 2); }
+#[test]
+fn round_trip_executable_3() { test_round_trip(EXECUTABLE, 3); }
+#[test]
+fn round_trip_executable_4() { test_round_trip(EXECUTABLE, 4); }
+#[test]
+fn round_trip_executable_5() { test_round_trip(EXECUTABLE, 5); }
+#[test]
+fn round_trip_executable_6() { test_round_trip(EXECUTABLE, 6); }
+#[test]
+fn round_trip_executable_7() { test_round_trip(EXECUTABLE, 7); }
+#[test]
+fn round_trip_executable_8() { test_round_trip(EXECUTABLE, 8); }
+#[test]
+fn round_trip_executable_9() { test_round_trip(EXECUTABLE, 9); }
+
+#[test]
+fn round_trip_pg100_0() { test_round_trip(PG100, 0); }
+#[test]
+fn round_trip_pg100_1() { test_round_trip(PG100, 1); }
+#[test]
+fn round_trip_pg100_2() { test_round_trip(PG100, 2); }
+#[test]
+fn round_trip_pg100_3() { test_round_trip(PG100, 3); }
+#[test]
+fn round_trip_pg100_4() { test_round_trip(PG100, 4); }
+#[test]
+fn round_trip_pg100_5() { test_round_trip(PG100, 5); }
+#[test]
+fn round_trip_pg100_6() { test_round_trip(PG100, 6); }
+#[test]
+fn round_trip_pg100_7() { test_round_trip(PG100, 7); }
+#[test]
+fn round_trip_pg100_8() { test_round_trip(PG100, 8); }
+#[test]
+fn round_trip_pg100_9() { test_round_trip(PG100, 9); }
+
+#[test]
+fn round_trip_pg6800_0() { test_round_trip(PG6800, 0); }
+#[test]
+fn round_trip_pg6800_1() { test_round_trip(PG6800, 1); }
+#[test]
+fn round_trip_pg6800_2() { test_round_trip(PG6800, 2); }
+#[test]
+fn round_trip_pg6800_3() { test_round_trip(PG6800, 3); }
+#[test]
+fn round_trip_pg6800_4() { test_round_trip(PG6800, 4); }
+#[test]
+fn round_trip_pg6800_5() { test_round_trip(PG6800, 5); }
+#[test]
+fn round_trip_pg6800_6() { test_round_trip(PG6800, 6); }
+#[test]
+fn round_trip_pg6800_7() { test_round_trip(PG6800, 7); }
+#[test]
+fn round_trip_pg6800_8() { test_round_trip(PG6800, 8); }
+#[test]
+fn round_trip_pg6800_9() { test_round_trip(PG6800, 9); }
+
+#[test]
+fn decode_tiny_output_buffer() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = encode_xz(&data, 6);
+
+    let mut decoder = XzStream::new(false);
+    let mut decompressed = Vec::new();
+    let mut output_buf = [0u8; 1];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&compressed[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+    assert!(decompressed == data);
+    assert_eq!(decoder.total_out(), data.len() as u64);
+    assert_eq!(decoder.total_in(), compressed.len() as u64);
+}
+
+#[test]
+fn cross_compat_with_xzreader() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = encode_xz(&data, 6);
+
+    let stream_result = decode_with_stream(&compressed);
+
+    let mut reader = lzma_rust2::XzReader::new(compressed.as_slice(), false);
+    let mut reader_result = Vec::new();
+    reader.read_to_end(&mut reader_result).unwrap();
+
+    assert_eq!(stream_result, reader_result);
+    assert!(stream_result == data);
+}
+
+#[test]
+fn decoder_total_tracking() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = encode_xz(&data, 6);
+
+    let mut decoder = XzStream::new(false);
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+    let mut total_produced = 0;
+
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&compressed[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        total_produced += result.bytes_produced;
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    assert_eq!(decoder.total_in(), compressed.len() as u64);
+    assert_eq!(decoder.total_out(), data.len() as u64);
+    assert_eq!(total_produced, data.len());
+}
+
+#[test]
+fn concatenated_streams() {
+    let data_a = std::fs::read(INPUT_HTML).unwrap();
+    let data_b = b"Second stream payload.";
+
+    let mut concatenated = encode_xz(&data_a, 6);
+    concatenated.extend_from_slice(&encode_xz(data_b, 3));
+
+    let mut decoder = XzStream::new(true);
+    let mut decompressed = Vec::new();
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= concatenated.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&concatenated[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    let mut expected = data_a.clone();
+    expected.extend_from_slice(data_b);
+    assert!(decompressed == expected);
+}
+
+#[test]
+fn zero_length_output_buffer() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = encode_xz(&data, 1);
+
+    let mut decoder = XzStream::new(false);
+    let mut output_buf = [0u8; 0];
+    let result = decoder
+        .process(&compressed, &mut output_buf, Action::Run)
+        .unwrap();
+    assert_eq!(result.bytes_produced, 0);
+}
+
+#[test]
+fn error_on_corrupted_payload() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let mut compressed = encode_xz(&data, 1);
+    let mid = compressed.len() / 2;
+    compressed[mid] ^= 0xFF;
+
+    let mut decoder = XzStream::new(false);
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    let mut errored = false;
+    for _ in 0..1000 {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        match decoder.process(&compressed[in_pos..], &mut output_buf, action) {
+            Ok(result) => {
+                in_pos += result.bytes_consumed;
+                if result.status == Status::StreamEnd {
+                    break;
+                }
+            }
+            Err(_) => {
+                errored = true;
+                break;
+            }
+        }
+    }
+    assert!(errored, "Expected error on corrupted payload");
+}
+
+#[test]
+fn process_after_stream_end() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = encode_xz(&data, 1);
+    let mut decoder = XzStream::new(false);
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&compressed[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    let result = decoder.process(&[], &mut output_buf, Action::Finish);
+    match result {
+        Ok(r) => {
+            assert_eq!(r.bytes_consumed, 0);
+            assert_eq!(r.bytes_produced, 0);
+        }
+        Err(_) => {}
+    }
+}
+
+#[test]
+fn error_on_corrupted_magic() {
+    let mut compressed = encode_xz(b"test", 1);
+    compressed[0] = 0xFF;
+
+    let mut decoder = XzStream::new(false);
+    let mut output_buf = [0u8; 4096];
+    let result = decoder.process(&compressed, &mut output_buf, Action::Run);
+    assert!(result.is_err());
+}
+
+#[test]
+fn error_on_truncated_input() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = encode_xz(&data, 1);
+    let truncated = &compressed[..compressed.len() / 2];
+
+    let mut decoder = XzStream::new(false);
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    let mut errored = false;
+    for _ in 0..1000 {
+        let action = if in_pos >= truncated.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        match decoder.process(&truncated[in_pos..], &mut output_buf, action) {
+            Ok(result) => {
+                in_pos += result.bytes_consumed;
+                if result.status == Status::StreamEnd {
+                    break;
+                }
+                if in_pos >= truncated.len() && result.bytes_consumed == 0 && result.bytes_produced == 0 {
+                    match decoder.process(&[], &mut output_buf, Action::Finish) {
+                        Ok(_) => break,
+                        Err(_) => {
+                            errored = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            Err(_) => {
+                errored = true;
+                break;
+            }
+        }
+    }
+    assert!(errored, "Expected error on truncated input");
+}
+
+fn decode_bcj_xz(compressed_path: &str, original_path: &str) {
+    let compressed = std::fs::read(compressed_path).unwrap();
+    let original = std::fs::read(original_path).unwrap();
+
+    let mut decoder = XzStream::new(false);
+    let mut decompressed = Vec::new();
+    let mut output_buf = [0u8; 4096];
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&compressed[in_pos..], &mut output_buf, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+    assert_eq!(decompressed.len(), original.len());
+    assert!(decompressed == original);
+}
+
+#[test]
+fn decode_bcj_x86() {
+    decode_bcj_xz("tests/data/wget-x86.xz", "tests/data/wget-x86");
+}
+
+#[test]
+fn decode_bcj_arm() {
+    decode_bcj_xz("tests/data/wget-arm.xz", "tests/data/wget-arm");
+}
+
+#[test]
+fn decode_bcj_arm64() {
+    decode_bcj_xz("tests/data/wget-arm64.xz", "tests/data/wget-arm64");
+}
+
+#[test]
+fn decode_bcj_arm_thumb() {
+    decode_bcj_xz("tests/data/wget-arm-thumb.xz", "tests/data/wget-arm-thumb");
+}
+
+#[test]
+fn decode_bcj_ia64() {
+    decode_bcj_xz("tests/data/wget-ia64.xz", "tests/data/wget-ia64");
+}
+
+#[test]
+fn decode_bcj_ppc() {
+    decode_bcj_xz("tests/data/wget-ppc.xz", "tests/data/wget-ppc");
+}
+
+#[test]
+fn decode_bcj_sparc() {
+    decode_bcj_xz("tests/data/wget-sparc.xz", "tests/data/wget-sparc");
+}
+
+#[test]
+fn decode_bcj_riscv() {
+    decode_bcj_xz("tests/data/wget-riscv.xz", "tests/data/wget-riscv");
+}
+
+#[test]
+fn decode_bcj_x86_byte_at_a_time() {
+    let compressed = std::fs::read("tests/data/wget-x86.xz").unwrap();
+    let original = std::fs::read("tests/data/wget-x86").unwrap();
+
+    let mut decoder = XzStream::new(false);
+    let mut decompressed = Vec::new();
+    let mut output_buf = [0u8; 4096];
+    let mut ci = 0;
+
+    while ci < compressed.len() {
+        let action = if ci == compressed.len() - 1 {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = decoder
+            .process(&compressed[ci..ci + 1], &mut output_buf, action)
+            .unwrap();
+        decompressed.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.bytes_consumed == 0 {
+            continue;
+        }
+        ci += result.bytes_consumed;
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+    assert_eq!(decompressed.len(), original.len());
+    assert!(decompressed == original);
+}

--- a/tests/xz_stream.rs
+++ b/tests/xz_stream.rs
@@ -61,67 +61,127 @@ fn round_trip_empty() {
 }
 
 #[test]
-fn round_trip_executable_0() { test_round_trip(EXECUTABLE, 0); }
+fn round_trip_executable_0() {
+    test_round_trip(EXECUTABLE, 0);
+}
 #[test]
-fn round_trip_executable_1() { test_round_trip(EXECUTABLE, 1); }
+fn round_trip_executable_1() {
+    test_round_trip(EXECUTABLE, 1);
+}
 #[test]
-fn round_trip_executable_2() { test_round_trip(EXECUTABLE, 2); }
+fn round_trip_executable_2() {
+    test_round_trip(EXECUTABLE, 2);
+}
 #[test]
-fn round_trip_executable_3() { test_round_trip(EXECUTABLE, 3); }
+fn round_trip_executable_3() {
+    test_round_trip(EXECUTABLE, 3);
+}
 #[test]
-fn round_trip_executable_4() { test_round_trip(EXECUTABLE, 4); }
+fn round_trip_executable_4() {
+    test_round_trip(EXECUTABLE, 4);
+}
 #[test]
-fn round_trip_executable_5() { test_round_trip(EXECUTABLE, 5); }
+fn round_trip_executable_5() {
+    test_round_trip(EXECUTABLE, 5);
+}
 #[test]
-fn round_trip_executable_6() { test_round_trip(EXECUTABLE, 6); }
+fn round_trip_executable_6() {
+    test_round_trip(EXECUTABLE, 6);
+}
 #[test]
-fn round_trip_executable_7() { test_round_trip(EXECUTABLE, 7); }
+fn round_trip_executable_7() {
+    test_round_trip(EXECUTABLE, 7);
+}
 #[test]
-fn round_trip_executable_8() { test_round_trip(EXECUTABLE, 8); }
+fn round_trip_executable_8() {
+    test_round_trip(EXECUTABLE, 8);
+}
 #[test]
-fn round_trip_executable_9() { test_round_trip(EXECUTABLE, 9); }
+fn round_trip_executable_9() {
+    test_round_trip(EXECUTABLE, 9);
+}
 
 #[test]
-fn round_trip_pg100_0() { test_round_trip(PG100, 0); }
+fn round_trip_pg100_0() {
+    test_round_trip(PG100, 0);
+}
 #[test]
-fn round_trip_pg100_1() { test_round_trip(PG100, 1); }
+fn round_trip_pg100_1() {
+    test_round_trip(PG100, 1);
+}
 #[test]
-fn round_trip_pg100_2() { test_round_trip(PG100, 2); }
+fn round_trip_pg100_2() {
+    test_round_trip(PG100, 2);
+}
 #[test]
-fn round_trip_pg100_3() { test_round_trip(PG100, 3); }
+fn round_trip_pg100_3() {
+    test_round_trip(PG100, 3);
+}
 #[test]
-fn round_trip_pg100_4() { test_round_trip(PG100, 4); }
+fn round_trip_pg100_4() {
+    test_round_trip(PG100, 4);
+}
 #[test]
-fn round_trip_pg100_5() { test_round_trip(PG100, 5); }
+fn round_trip_pg100_5() {
+    test_round_trip(PG100, 5);
+}
 #[test]
-fn round_trip_pg100_6() { test_round_trip(PG100, 6); }
+fn round_trip_pg100_6() {
+    test_round_trip(PG100, 6);
+}
 #[test]
-fn round_trip_pg100_7() { test_round_trip(PG100, 7); }
+fn round_trip_pg100_7() {
+    test_round_trip(PG100, 7);
+}
 #[test]
-fn round_trip_pg100_8() { test_round_trip(PG100, 8); }
+fn round_trip_pg100_8() {
+    test_round_trip(PG100, 8);
+}
 #[test]
-fn round_trip_pg100_9() { test_round_trip(PG100, 9); }
+fn round_trip_pg100_9() {
+    test_round_trip(PG100, 9);
+}
 
 #[test]
-fn round_trip_pg6800_0() { test_round_trip(PG6800, 0); }
+fn round_trip_pg6800_0() {
+    test_round_trip(PG6800, 0);
+}
 #[test]
-fn round_trip_pg6800_1() { test_round_trip(PG6800, 1); }
+fn round_trip_pg6800_1() {
+    test_round_trip(PG6800, 1);
+}
 #[test]
-fn round_trip_pg6800_2() { test_round_trip(PG6800, 2); }
+fn round_trip_pg6800_2() {
+    test_round_trip(PG6800, 2);
+}
 #[test]
-fn round_trip_pg6800_3() { test_round_trip(PG6800, 3); }
+fn round_trip_pg6800_3() {
+    test_round_trip(PG6800, 3);
+}
 #[test]
-fn round_trip_pg6800_4() { test_round_trip(PG6800, 4); }
+fn round_trip_pg6800_4() {
+    test_round_trip(PG6800, 4);
+}
 #[test]
-fn round_trip_pg6800_5() { test_round_trip(PG6800, 5); }
+fn round_trip_pg6800_5() {
+    test_round_trip(PG6800, 5);
+}
 #[test]
-fn round_trip_pg6800_6() { test_round_trip(PG6800, 6); }
+fn round_trip_pg6800_6() {
+    test_round_trip(PG6800, 6);
+}
 #[test]
-fn round_trip_pg6800_7() { test_round_trip(PG6800, 7); }
+fn round_trip_pg6800_7() {
+    test_round_trip(PG6800, 7);
+}
 #[test]
-fn round_trip_pg6800_8() { test_round_trip(PG6800, 8); }
+fn round_trip_pg6800_8() {
+    test_round_trip(PG6800, 8);
+}
 #[test]
-fn round_trip_pg6800_9() { test_round_trip(PG6800, 9); }
+fn round_trip_pg6800_9() {
+    test_round_trip(PG6800, 9);
+}
 
 #[test]
 fn decode_tiny_output_buffer() {
@@ -347,7 +407,10 @@ fn error_on_truncated_input() {
                 if result.status == Status::StreamEnd {
                     break;
                 }
-                if in_pos >= truncated.len() && result.bytes_consumed == 0 && result.bytes_produced == 0 {
+                if in_pos >= truncated.len()
+                    && result.bytes_consumed == 0
+                    && result.bytes_produced == 0
+                {
                     match decoder.process(&[], &mut output_buf, Action::Finish) {
                         Ok(_) => break,
                         Err(_) => {


### PR DESCRIPTION
Add sans-I/O decoders for LZMA2 and XZ (as suggested in #101 and #103):

Changes:
- Change visibility of multiple structs, methods, etc. into `pub(crate)` so the new decoders could reuse existing `RangeDecoder`, `LzDecoder`, and filter implementations without duplication.
- Add `Lzma2Stream` and `XzStream`: 2 buffer-pair decoders that take `input`/`output` slices along with an `action`, then return how many bytes were consumed/produced, with no internal I/O. This makes them usable in cases where `std::io::Read` is inconvenient.
- Expose `Action`, `Status`, and `StreamResult` types as the shared interface for both decoders.