### PR TITLE
Add sans-I/O decoders for LZMA and Lzip

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -17,6 +17,7 @@ jobs:
         target:
           - lzip
           - lzma
+          - lzma_stream
           - lzma2
           - lzma2_stream
           - xz

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         target:
           - lzip
+          - lzip_stream
           - lzma
           - lzma_stream
           - lzma2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.0 - 2026-08-11
+
+- Add sans-I/O decoders for LZMA1 and LZIP (#109)
+
 ## 0.18.1 - 2026-08-05
 
 ### Fixed

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,6 +24,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "lzma_stream"
+path = "fuzz_targets/lzma_stream.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "lzma2"
 path = "fuzz_targets/lzma2.rs"
 test = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,6 +18,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "lzip_stream"
+path = "fuzz_targets/lzip_stream.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "lzma"
 path = "fuzz_targets/lzma.rs"
 test = false

--- a/fuzz/fuzz_targets/lzip_stream.rs
+++ b/fuzz/fuzz_targets/lzip_stream.rs
@@ -1,0 +1,79 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use lzma_rust2::{Action, LzipStream, Status};
+
+/// How much input to hand over in one call. A member hands back up to 40 bytes
+/// when it ends, so 19/20/21 and 39/40/41 sit right on the edges where that
+/// spills past the trailer into the next member.
+const CHUNK_SIZES: [usize; 16] = [1, 1, 2, 3, 5, 7, 19, 20, 21, 32, 39, 40, 41, 64, 512, 4096];
+
+/// How much room to give the output.
+const OUTPUT_SIZES: [usize; 8] = [1, 1, 2, 7, 19, 64, 512, 4096];
+
+const MAX_OUTPUT: usize = 1 << 18;
+const MAX_STEPS: usize = 4096;
+
+/// A member header may ask for a dictionary of up to 512 MiB, and a file can
+/// hold any number of members, so the limit is what keeps a few input bytes from
+/// turning into minutes of allocating.
+const MEM_LIMIT_KB: u32 = 8 * 1024;
+
+/// The first eight bytes say how to feed the decoder.
+const PLAN_LEN: usize = 8;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < PLAN_LEN {
+        return;
+    }
+    let (plan, stream) = data.split_at(PLAN_LEN);
+
+    let mut decoder = LzipStream::new_mem_limit(MEM_LIMIT_KB);
+
+    let mut output = [0u8; 4096];
+    let mut in_pos = 0usize;
+    let mut total_out = 0usize;
+
+    for step in 0..MAX_STEPS {
+        // One plan byte per call: the low half picks the chunk size, the high
+        // half picks the output size. Reading the plan from the input rather
+        // than from a random number generator means changing one byte changes
+        // one call, which is what lets the fuzzer learn from what it tries.
+        let choice = plan[step % PLAN_LEN];
+        let chunk = CHUNK_SIZES[(choice & 0x0F) as usize];
+        let out_len = OUTPUT_SIZES[(choice >> 4) as usize % OUTPUT_SIZES.len()];
+
+        let end = in_pos.saturating_add(chunk).min(stream.len());
+        let action = if end >= stream.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+
+        let result = match decoder.process(&stream[in_pos..end], &mut output[..out_len], action) {
+            Ok(result) => result,
+            Err(_) => return,
+        };
+
+        in_pos += result.bytes_consumed;
+        total_out += result.bytes_produced;
+
+        if result.status == Status::StreamEnd {
+            return;
+        }
+
+        // Every call has to do something. The output buffer is never empty, and
+        // the input slice is only empty once we have already said Finish, so
+        // there is no case here where doing nothing is allowed.
+        assert!(
+            result.bytes_consumed != 0 || result.bytes_produced != 0,
+            "process() did nothing at input {in_pos}/{} with {out_len} bytes of output space \
+             and {action:?}",
+            stream.len(),
+        );
+
+        if total_out > MAX_OUTPUT {
+            return;
+        }
+    }
+});

--- a/fuzz/fuzz_targets/lzma_stream.rs
+++ b/fuzz/fuzz_targets/lzma_stream.rs
@@ -1,0 +1,114 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use lzma_rust2::{Action, LzmaStream, Status};
+
+/// How much input to hand over in one call. A symbol is at most 20 bytes long
+/// and the carry buffer holds 40, so 19/20/21 and 39/40/41 sit right on the
+/// edges where the decoder changes what it does.
+const CHUNK_SIZES: [usize; 16] = [1, 1, 2, 3, 5, 7, 19, 20, 21, 32, 39, 40, 41, 64, 512, 4096];
+
+/// How much room to give the output.
+const OUTPUT_SIZES: [usize; 8] = [1, 1, 2, 7, 19, 64, 512, 4096];
+
+const MAX_OUTPUT: usize = 1 << 18;
+const MAX_STEPS: usize = 4096;
+
+const MEM_LIMIT_KB: u32 = 8 * 1024;
+
+/// First 8 bytes say how to build the decoder, next 8 say how to feed it.
+const HEAD_LEN: usize = 8;
+const PLAN_LEN: usize = 8;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < HEAD_LEN + PLAN_LEN {
+        return;
+    }
+    let (head, tail) = data.split_at(HEAD_LEN);
+    let (plan, rest) = tail.split_at(PLAN_LEN);
+
+    let uncomp_size = if head[0] & 1 != 0 {
+        u16::from_le_bytes([head[6], head[7]]) as u64
+    } else {
+        u64::MAX
+    };
+
+    // Kept small, because the raw constructors have no memory limit of their own.
+    let dict_size = u16::from_le_bytes([head[4], head[5]]) as u32;
+
+    let preset_len = if head[0] & 2 != 0 {
+        (head[3] as usize * 4).min(rest.len())
+    } else {
+        0
+    };
+    let (preset, stream) = rest.split_at(preset_len);
+    let preset_dict = (!preset.is_empty()).then_some(preset);
+
+    let mut decoder = match (head[0] >> 2) & 3 {
+        // With a header, so the stream itself supplies dict_size and uncomp_size.
+        0 => LzmaStream::new_mem_limit(MEM_LIMIT_KB, preset_dict),
+        // Raw. The properties byte is passed through untouched so that the
+        // checks on it get fuzzed too.
+        1 => match LzmaStream::new_with_props(uncomp_size, head[1], dict_size, preset_dict) {
+            Ok(decoder) => decoder,
+            Err(_) => return,
+        },
+        // Raw, with lc, lp and pb given separately.
+        _ => {
+            let lc = (head[1] % 9) as u32;
+            let lp = ((head[1] >> 4) % 5) as u32;
+            let pb = (head[2] % 5) as u32;
+            match LzmaStream::new(uncomp_size, lc, lp, pb, dict_size, preset_dict) {
+                Ok(decoder) => decoder,
+                Err(_) => return,
+            }
+        }
+    };
+
+    let mut output = [0u8; 4096];
+    let mut in_pos = 0usize;
+    let mut total_out = 0usize;
+
+    for step in 0..MAX_STEPS {
+        // One plan byte per call: the low half picks the chunk size, the high
+        // half picks the output size. Reading the plan from the input rather
+        // than from a random number generator means changing one byte changes
+        // one call, which is what lets the fuzzer learn from what it tries.
+        let choice = plan[step % PLAN_LEN];
+        let chunk = CHUNK_SIZES[(choice & 0x0F) as usize];
+        let out_len = OUTPUT_SIZES[(choice >> 4) as usize % OUTPUT_SIZES.len()];
+
+        let end = in_pos.saturating_add(chunk).min(stream.len());
+        let action = if end >= stream.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+
+        let result = match decoder.process(&stream[in_pos..end], &mut output[..out_len], action) {
+            Ok(result) => result,
+            Err(_) => return,
+        };
+
+        in_pos += result.bytes_consumed;
+        total_out += result.bytes_produced;
+
+        if result.status == Status::StreamEnd {
+            return;
+        }
+
+        // Every call has to do something. The output buffer is never empty, and
+        // the input slice is only empty once we have already said Finish, so
+        // there is no case here where doing nothing is allowed.
+        assert!(
+            result.bytes_consumed != 0 || result.bytes_produced != 0,
+            "process() did nothing at input {in_pos}/{} with {out_len} bytes of output space \
+             and {action:?}",
+            stream.len(),
+        );
+
+        if total_out > MAX_OUTPUT {
+            return;
+        }
+    }
+});

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -53,7 +53,7 @@ impl LzmaDecoder {
         rc: &mut RangeDecoder<R>,
     ) -> crate::Result<()> {
         lz.repeat_pending()?;
-        while lz.has_space() {
+        while lz.has_space() && rc.can_start_symbol() {
             let pos_state = lz.get_pos() as u32 & self.coder.pos_mask;
             let i = self.coder.state.get() as usize;
             let probs = &mut self.coder.is_match[i];
@@ -70,7 +70,14 @@ impl LzmaDecoder {
                 lz.repeat(self.coder.reps[0] as _, len as _)?;
             }
         }
-        rc.normalize();
+        // Normalise only if we stopped because the output is full. If we
+        // stopped because the input ran out, `rc` has to stay as it is, so that
+        // the next call can pick up where this one left off. A reader that
+        // never runs out of input, like `RangeDecoderBuffer`, always takes this
+        // branch, just like before.
+        if !lz.has_space() && rc.can_normalize() {
+            rc.normalize();
+        }
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,14 +93,14 @@ pub(crate) use std::io::Write;
 #[cfg(feature = "encoder")]
 pub use enc::*;
 pub use lz::MfType;
-#[cfg(feature = "lzip")]
-pub use lzip::LzipReader;
 #[cfg(all(feature = "lzip", feature = "std"))]
 pub use lzip::LzipReaderMt;
 #[cfg(all(feature = "lzip", feature = "encoder", feature = "std"))]
 pub use lzip::LzipWriterMt;
 #[cfg(all(feature = "lzip", feature = "encoder"))]
 pub use lzip::{LzipOptions, LzipWriter};
+#[cfg(feature = "lzip")]
+pub use lzip::{LzipReader, LzipStream};
 pub use lzma_reader::{
     LzmaReader, LzmaStream, get_memory_usage as lzma_get_memory_usage,
     get_memory_usage_by_props as lzma_get_memory_usage_by_props,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ mod lzma2_reader;
 mod lzma_reader;
 mod range_dec;
 mod state;
+mod stream;
 #[cfg(feature = "std")]
 mod work_queue;
 #[cfg(feature = "xz")]
@@ -104,10 +105,7 @@ pub use lzma_reader::{
     LzmaReader, LzmaStream, get_memory_usage as lzma_get_memory_usage,
     get_memory_usage_by_props as lzma_get_memory_usage_by_props,
 };
-pub use lzma2_reader::{
-    Action, Lzma2Reader, Lzma2Stream, Status, StreamResult,
-    get_memory_usage as lzma2_get_memory_usage,
-};
+pub use lzma2_reader::{Lzma2Reader, Lzma2Stream, get_memory_usage as lzma2_get_memory_usage};
 #[cfg(feature = "std")]
 pub use lzma2_reader_mt::Lzma2ReaderMt;
 #[cfg(not(feature = "std"))]
@@ -117,6 +115,7 @@ pub use no_std::Read;
 #[cfg(not(feature = "std"))]
 pub use no_std::Write;
 use state::*;
+pub use stream::{Action, Status, StreamResult};
 #[cfg(all(feature = "xz", feature = "std"))]
 pub use xz::XzReaderMt;
 #[cfg(all(feature = "xz", feature = "encoder", feature = "std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub use lzip::LzipWriterMt;
 #[cfg(all(feature = "lzip", feature = "encoder"))]
 pub use lzip::{LzipOptions, LzipWriter};
 pub use lzma_reader::{
-    LzmaReader, get_memory_usage as lzma_get_memory_usage,
+    LzmaReader, LzmaStream, get_memory_usage as lzma_get_memory_usage,
     get_memory_usage_by_props as lzma_get_memory_usage_by_props,
 };
 pub use lzma2_reader::{

--- a/src/lzip.rs
+++ b/src/lzip.rs
@@ -1,6 +1,7 @@
 //! LZIP format implementation.
 
 mod reader;
+mod stream;
 
 #[cfg(feature = "std")]
 mod reader_mt;
@@ -17,6 +18,7 @@ use std::io::{Seek, SeekFrom};
 pub use reader::LzipReader;
 #[cfg(feature = "std")]
 pub use reader_mt::LzipReaderMt;
+pub use stream::LzipStream;
 #[cfg(feature = "encoder")]
 pub use writer::{LzipOptions, LzipWriter};
 #[cfg(all(feature = "encoder", feature = "std"))]

--- a/src/lzip/stream.rs
+++ b/src/lzip/stream.rs
@@ -1,0 +1,466 @@
+use alloc::vec::Vec;
+
+use super::{HEADER_SIZE, LZIP_MAGIC, LZIP_VERSION, TRAILER_SIZE, decode_dict_size};
+use crate::{
+    Action, LzmaStream, Result, Status, StreamResult, crc::Crc32, error_invalid_data,
+    error_out_of_memory, lzma_reader::get_memory_usage,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LzipState {
+    /// Collecting the six byte member header.
+    Header,
+    /// Decoding the member payload.
+    LzmaData,
+    /// Collecting the twenty byte member trailer.
+    Trailer,
+    Finished,
+}
+
+/// The bytes to read next: the pushback queue while it still has any, then the
+/// caller's input. The flag says which one it is, because only bytes taken from
+/// the caller may be counted.
+fn source<'a>(pending: &'a [u8], input: &'a [u8]) -> (&'a [u8], bool) {
+    if pending.is_empty() {
+        (input, true)
+    } else {
+        (pending, false)
+    }
+}
+
+/// Validates a member header and returns its dictionary size.
+fn parse_header(header: &[u8]) -> Result<u32> {
+    if header[..4] != LZIP_MAGIC {
+        return Err(error_invalid_data("invalid LZIP magic bytes"));
+    }
+    if header[4] != LZIP_VERSION {
+        return Err(error_invalid_data("unsupported LZIP version"));
+    }
+    decode_dict_size(header[5])
+}
+
+/// A sans-I/O LZIP stream decoder.
+///
+/// Unlike [`LzipReader`] this pulls no bytes on its own: call [`process()`] with
+/// an input slice and an output slice until it returns [`Status::StreamEnd`].
+///
+/// Every call consumes the whole `input` slice unless the output buffer filled
+/// first or the stream ended, so the caller never has to re-present bytes.
+///
+/// Members are decoded one after another, so a concatenation of LZIP files
+/// decodes as if it were one file.
+///
+/// [`LzipReader`]: crate::LzipReader
+/// [`process()`]: LzipStream::process
+///
+/// # Examples
+/// ```
+/// use lzma_rust2::{Action, LzipStream, Status};
+///
+/// let compressed: Vec<u8> = vec![
+///     76, 90, 73, 80, 1, 23, 0, 36, 25, 73, 152, 111, 22, 2, 140, 232, 230, 91, 177, 71, 198,
+///     206, 183, 99, 255, 255, 60, 172, 0, 0, 230, 198, 230, 235, 13, 0, 0, 0, 0, 0, 0, 0, 50, 0,
+///     0, 0, 0, 0, 0, 0,
+/// ];
+///
+/// let mut stream = LzipStream::new();
+/// let mut buf = [0; 1024];
+/// let mut out = Vec::new();
+/// let mut consumed = 0;
+/// loop {
+///     let result = stream
+///         .process(&compressed[consumed..], &mut buf, Action::Finish)
+///         .unwrap();
+///     consumed += result.bytes_consumed;
+///     out.extend_from_slice(&buf[..result.bytes_produced]);
+///     if result.status == Status::StreamEnd {
+///         break;
+///     }
+/// }
+/// assert_eq!(out, b"Hello, world!");
+/// ```
+pub struct LzipStream {
+    state: LzipState,
+    /// The current member's payload decoder.
+    lzma: Option<LzmaStream>,
+    /// Header or trailer bytes, whichever the state is collecting.
+    accum: Vec<u8>,
+    accum_needed: usize,
+    /// Bytes a finished member handed back because they belong to what follows
+    /// it. They are read before the caller's input.
+    pending: Vec<u8>,
+    pending_pos: usize,
+    crc: Crc32,
+    /// Bytes the current member has decoded.
+    data_size: u64,
+    /// Payload bytes the current member has used.
+    member_compressed: u64,
+    members: usize,
+    mem_limit_kb: u32,
+    /// Bytes that belong to no member. Filled in once the stream ends.
+    leftover: Vec<u8>,
+    total_in: u64,
+    total_out: u64,
+}
+
+impl Default for LzipStream {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LzipStream {
+    /// Creates a decompressor for the LZIP file format with no memory limit.
+    pub fn new() -> Self {
+        Self::new_mem_limit(u32::MAX)
+    }
+
+    /// Creates a decompressor for the LZIP file format with a memory usage
+    /// limit.
+    /// - `mem_limit_kb` - memory usage limit in kibibytes (KiB). `u32::MAX` means no limit.
+    ///
+    /// Each member header is checked against the limit as it is parsed, so
+    /// violations surface from [`process()`] rather than from here.
+    ///
+    /// [`process()`]: LzipStream::process
+    pub fn new_mem_limit(mem_limit_kb: u32) -> Self {
+        Self {
+            state: LzipState::Header,
+            lzma: None,
+            accum: Vec::with_capacity(TRAILER_SIZE),
+            accum_needed: HEADER_SIZE,
+            pending: Vec::new(),
+            pending_pos: 0,
+            crc: Crc32::new(),
+            data_size: 0,
+            member_compressed: 0,
+            members: 0,
+            mem_limit_kb,
+            leftover: Vec::new(),
+            total_in: 0,
+            total_out: 0,
+        }
+    }
+
+    /// Total bytes consumed from input across all `process()` calls.
+    ///
+    /// This includes the [`unused_input()`] bytes.
+    ///
+    /// [`unused_input()`]: LzipStream::unused_input
+    pub fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    /// Total bytes produced to output across all `process()` calls.
+    pub fn total_out(&self) -> u64 {
+        self.total_out
+    }
+
+    /// Returns true if the LZIP stream has been fully decoded.
+    pub fn is_finished(&self) -> bool {
+        self.state == LzipState::Finished
+    }
+
+    /// Returns true if there is decoded output waiting to be flushed.
+    pub fn has_output(&self) -> bool {
+        self.lzma.as_ref().is_some_and(|lzma| lzma.has_output())
+    }
+
+    /// Number of members that have been decoded and verified so far.
+    pub fn member_count(&self) -> usize {
+        self.members
+    }
+
+    /// Bytes that were absorbed from the caller but turned out not to belong to
+    /// any member.
+    ///
+    /// Only meaningful once [`Status::StreamEnd`] has been returned; before that
+    /// it is always empty.
+    ///
+    /// Since `process()` always takes the whole input, everything behind the
+    /// last member comes back as `unused_input()` plus whatever is left past
+    /// `bytes_consumed` in the last slice that was passed in.
+    pub fn unused_input(&self) -> &[u8] {
+        if self.state == LzipState::Finished {
+            &self.leftover
+        } else {
+            &[]
+        }
+    }
+
+    /// Process available LZIP data from `input` into `output`.
+    pub fn process(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+    ) -> Result<StreamResult> {
+        let mut in_pos = 0;
+        let mut out_pos = 0;
+
+        loop {
+            match self.state {
+                LzipState::Finished => {
+                    return Ok(StreamResult {
+                        bytes_consumed: in_pos,
+                        bytes_produced: out_pos,
+                        status: Status::StreamEnd,
+                    });
+                }
+
+                LzipState::Header => {
+                    if let Some(result) = self.accumulate(input, action, &mut in_pos, out_pos)? {
+                        return Ok(result);
+                    }
+
+                    let dict_size = match parse_header(&self.accum) {
+                        Ok(dict_size) => dict_size,
+                        Err(error) => {
+                            // Only the first member has to be there. Behind a
+                            // decoded one this is trailing data, which the
+                            // caller gets back instead of an error.
+                            if self.members == 0 {
+                                return Err(error);
+                            }
+                            self.finish();
+                            return Ok(StreamResult {
+                                bytes_consumed: in_pos,
+                                bytes_produced: out_pos,
+                                status: Status::StreamEnd,
+                            });
+                        }
+                    };
+
+                    self.start_member(dict_size)?;
+                }
+
+                LzipState::LzmaData => {
+                    if let Some(result) =
+                        self.decode_payload(input, output, action, &mut in_pos, &mut out_pos)?
+                    {
+                        return Ok(result);
+                    }
+                }
+
+                LzipState::Trailer => {
+                    if let Some(result) = self.accumulate(input, action, &mut in_pos, out_pos)? {
+                        return Ok(result);
+                    }
+                    self.verify_trailer()?;
+                }
+            }
+        }
+    }
+
+    /// Fills `accum` up to `accum_needed` bytes, returning a result to hand back
+    /// to the caller when the input ran dry first.
+    fn accumulate(
+        &mut self,
+        input: &[u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: usize,
+    ) -> Result<Option<StreamResult>> {
+        while self.accum.len() < self.accum_needed {
+            let (buf, from_caller) = source(&self.pending[self.pending_pos..], &input[*in_pos..]);
+
+            if buf.is_empty() {
+                if action != Action::Finish {
+                    return Ok(Some(StreamResult {
+                        bytes_consumed: *in_pos,
+                        bytes_produced: out_pos,
+                        status: Status::Ok,
+                    }));
+                }
+
+                // A header that never arrives is just the end of the file, as
+                // long as a member has already been decoded. Anything else is a
+                // truncated stream.
+                if self.state != LzipState::Header || self.members == 0 {
+                    return Err(error_invalid_data("unexpected end of LZIP stream"));
+                }
+
+                self.finish();
+                return Ok(Some(StreamResult {
+                    bytes_consumed: *in_pos,
+                    bytes_produced: out_pos,
+                    status: Status::StreamEnd,
+                }));
+            }
+
+            let to_copy = (self.accum_needed - self.accum.len()).min(buf.len());
+            self.accum.extend_from_slice(&buf[..to_copy]);
+
+            if from_caller {
+                *in_pos += to_copy;
+                self.total_in += to_copy as u64;
+            } else {
+                self.pending_pos += to_copy;
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Sets up the payload decoder for a member.
+    fn start_member(&mut self, dict_size: u32) -> Result<()> {
+        // Check the memory limit before allocating anything.
+        let need_mem = get_memory_usage(dict_size, 3, 0)?;
+        if self.mem_limit_kb < need_mem {
+            return Err(error_out_of_memory(
+                "needed memory too big for mem_limit_kb",
+            ));
+        }
+
+        // LZIP fixes lc=3, lp=0 and pb=2, and the payload carries no size, so
+        // only its end marker says where it stops.
+        self.lzma = Some(LzmaStream::new(u64::MAX, 3, 0, 2, dict_size, None)?);
+
+        self.crc = Crc32::new();
+        self.data_size = 0;
+        self.member_compressed = 0;
+        self.accum.clear();
+        self.accum_needed = 0;
+        self.state = LzipState::LzmaData;
+        Ok(())
+    }
+
+    /// Runs the payload decoder once, returning a result to hand back to the
+    /// caller when it needs more input or more output space.
+    fn decode_payload(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: &mut usize,
+    ) -> Result<Option<StreamResult>> {
+        let (buf, from_caller) = source(&self.pending[self.pending_pos..], &input[*in_pos..]);
+
+        // The caller's input is still queued behind the pushback, so saying that
+        // the stream ends here would make the payload decoder report a
+        // truncation that is not there.
+        let action = if from_caller { action } else { Action::Run };
+
+        let lzma = self
+            .lzma
+            .as_mut()
+            .ok_or_else(|| error_invalid_data("payload decoder not set"))?;
+        let result = lzma.process(buf, &mut output[*out_pos..], action)?;
+
+        if from_caller {
+            *in_pos += result.bytes_consumed;
+            self.total_in += result.bytes_consumed as u64;
+        } else {
+            self.pending_pos += result.bytes_consumed;
+        }
+
+        if result.bytes_produced > 0 {
+            self.crc
+                .update(&output[*out_pos..*out_pos + result.bytes_produced]);
+            self.data_size += result.bytes_produced as u64;
+            *out_pos += result.bytes_produced;
+            self.total_out += result.bytes_produced as u64;
+        }
+
+        if result.status == Status::StreamEnd {
+            self.finish_payload();
+            return Ok(None);
+        }
+
+        // The last condition is what keeps a payload decoder that can make no
+        // progress at all from being called forever.
+        if (from_caller && *in_pos >= input.len())
+            || *out_pos >= output.len()
+            || (result.bytes_consumed == 0 && result.bytes_produced == 0)
+        {
+            return Ok(Some(StreamResult {
+                bytes_consumed: *in_pos,
+                bytes_produced: *out_pos,
+                status: Status::Ok,
+            }));
+        }
+
+        Ok(None)
+    }
+
+    /// Ends the payload and queues the bytes the decoder read past it.
+    fn finish_payload(&mut self) {
+        let lzma = self.lzma.take().expect("payload decoder not set");
+        let unused = lzma.unused_input();
+
+        // A byte counts as consumed the moment it is taken in, decoded or not,
+        // so the ones handed back have to come off the member's size again.
+        self.member_compressed = lzma.total_in() - unused.len() as u64;
+
+        // They go in front of what is still queued: the payload decoder saw
+        // them first.
+        self.pending.drain(..self.pending_pos);
+        self.pending_pos = 0;
+        self.pending.splice(..0, unused.iter().copied());
+
+        self.accum.clear();
+        self.accum_needed = TRAILER_SIZE;
+        self.state = LzipState::Trailer;
+    }
+
+    /// Checks the member against its trailer and moves on to the next one.
+    fn verify_trailer(&mut self) -> Result<()> {
+        let crc32 =
+            u32::from_le_bytes([self.accum[0], self.accum[1], self.accum[2], self.accum[3]]);
+        let data_size = u64::from_le_bytes([
+            self.accum[4],
+            self.accum[5],
+            self.accum[6],
+            self.accum[7],
+            self.accum[8],
+            self.accum[9],
+            self.accum[10],
+            self.accum[11],
+        ]);
+        let member_size = u64::from_le_bytes([
+            self.accum[12],
+            self.accum[13],
+            self.accum[14],
+            self.accum[15],
+            self.accum[16],
+            self.accum[17],
+            self.accum[18],
+            self.accum[19],
+        ]);
+
+        if self.crc.finalize() != crc32 {
+            return Err(error_invalid_data("LZIP CRC32 mismatch"));
+        }
+
+        if self.data_size != data_size {
+            return Err(error_invalid_data("LZIP data size mismatch"));
+        }
+
+        let actual_member_size = HEADER_SIZE as u64 + self.member_compressed + TRAILER_SIZE as u64;
+        if actual_member_size != member_size {
+            return Err(error_invalid_data("LZIP member size mismatch"));
+        }
+
+        self.members += 1;
+        self.accum.clear();
+        self.accum_needed = HEADER_SIZE;
+        self.state = LzipState::Header;
+        Ok(())
+    }
+
+    /// Ends the stream, keeping what is left for [`unused_input()`].
+    ///
+    /// [`unused_input()`]: LzipStream::unused_input
+    fn finish(&mut self) {
+        self.leftover.clear();
+        self.leftover.extend_from_slice(&self.accum);
+        self.leftover
+            .extend_from_slice(&self.pending[self.pending_pos..]);
+
+        self.accum.clear();
+        self.pending.clear();
+        self.pending_pos = 0;
+        self.state = LzipState::Finished;
+    }
+}

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -7,7 +7,10 @@ use super::{
     lz::LzDecoder,
     range_dec::{RangeDecoder, RangeDecoderBuffer},
 };
-use crate::{ByteReader, DICT_SIZE_MIN};
+use crate::{
+    ByteReader, DICT_SIZE_MIN,
+    stream::{Action, Status, StreamResult},
+};
 
 pub const COMPRESSED_SIZE_MAX: u32 = 1 << 16;
 
@@ -224,37 +227,6 @@ impl<R: Read> Read for Lzma2Reader<R> {
 
         Ok(size)
     }
-}
-
-// ── Sans-I/O stream types ───────────────────────────────────────────────────
-
-/// Action to perform during stream processing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Action {
-    /// Process available data without flushing.
-    Run,
-    /// Signal that no more input will be provided.
-    Finish,
-}
-
-/// Status returned by stream processing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Status {
-    /// More input or output space needed to continue.
-    Ok,
-    /// The stream has been fully processed.
-    StreamEnd,
-}
-
-/// Result of a single `process()` call.
-#[derive(Debug, Clone, Copy)]
-pub struct StreamResult {
-    /// Number of bytes consumed from the input buffer.
-    pub bytes_consumed: usize,
-    /// Number of bytes written to the output buffer.
-    pub bytes_produced: usize,
-    /// Current stream status.
-    pub status: Status,
 }
 
 #[derive(Clone, Copy)]

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -1,6 +1,12 @@
-use super::{
-    ByteReader, DICT_SIZE_MAX, Read, decoder::LzmaDecoder, error_invalid_data, error_invalid_input,
-    error_out_of_memory, lz::LzDecoder, range_dec::RangeDecoder,
+use alloc::vec::Vec;
+
+use crate::{
+    ByteReader, DICT_SIZE_MAX, Read,
+    decoder::LzmaDecoder,
+    error_invalid_data, error_invalid_input, error_out_of_memory,
+    lz::LzDecoder,
+    lzma2_reader::{Action, Status, StreamResult},
+    range_dec::{RangeCoderState, RangeDecoder, SliceRangeReader},
 };
 
 /// Calculates the memory usage in KiB required for LZMA decompression from properties byte.
@@ -271,4 +277,724 @@ impl<R: Read> Read for LzmaReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
         self.read_decode(buf)
     }
+}
+
+/// Minimum number of input bytes needed to safely decode one LZMA symbol.
+///
+/// The worst case is a match with the maximum length at the maximum distance:
+/// 22 probability-coded bits plus 26 direct bits, which together can consume at
+/// most 20 input bytes.
+const IN_REQUIRED: usize = 20;
+
+/// Capacity of the carry buffer: up to 19 bytes left over from the last call,
+/// plus 20 fresh ones.
+///
+/// Those 20 are what lets a pass use up the leftovers and carry on decoding
+/// straight out of the caller's buffer.
+const CARRY_CAP: usize = 2 * IN_REQUIRED;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LzmaState {
+    Header,
+    RcInit,
+    Decode,
+    DrainOutput,
+    Finished,
+}
+
+/// Output space the decoder may fill before it has to stop.
+fn room_for(lz: Option<&LzDecoder>, remaining_size: u64) -> usize {
+    let Some(lz) = lz else {
+        return 0;
+    };
+    let mut room = lz.available_space();
+    if remaining_size <= u64::MAX / 2 {
+        room = room.min(remaining_size.min(usize::MAX as u64) as usize);
+    }
+    room
+}
+
+/// A sans-I/O LZMA1 stream decoder.
+///
+/// Unlike [`LzmaReader`] this pulls no bytes on its own: call [`process()`] with
+/// an input slice and an output slice until it returns [`Status::StreamEnd`].
+///
+/// Every call consumes the whole `input` slice unless the output buffer filled
+/// first or the stream ended, so the caller never has to re-present bytes.
+///
+/// [`process()`]: LzmaStream::process
+///
+/// # Examples
+/// ```
+/// use lzma_rust2::{Action, LzmaStream, Status};
+///
+/// let compressed: Vec<u8> = vec![
+///     93, 0, 0, 128, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 36, 25, 73, 152, 111, 22, 2,
+///     140, 232, 230, 91, 177, 71, 198, 206, 183, 99, 255, 255, 60, 172, 0, 0,
+/// ];
+///
+/// let mut stream = LzmaStream::new_mem_limit(u32::MAX, None);
+/// let mut buf = [0; 1024];
+/// let mut out = Vec::new();
+/// let mut consumed = 0;
+/// loop {
+///     let result = stream
+///         .process(&compressed[consumed..], &mut buf, Action::Finish)
+///         .unwrap();
+///     consumed += result.bytes_consumed;
+///     out.extend_from_slice(&buf[..result.bytes_produced]);
+///     if result.status == Status::StreamEnd {
+///         break;
+///     }
+/// }
+/// assert_eq!(out, b"Hello, world!");
+/// ```
+pub struct LzmaStream {
+    state: LzmaState,
+    /// `None` until the dictionary size is known (header mode).
+    lz: Option<LzDecoder>,
+    /// `None` until the properties byte is known (header mode).
+    lzma: Option<LzmaDecoder>,
+    rc: RangeCoderState,
+    /// Bytes taken from the caller that were too few to start a symbol from.
+    carry: [u8; CARRY_CAP],
+    carry_len: usize,
+    /// Header and range-coder-init bytes.
+    accum: Vec<u8>,
+    accum_needed: usize,
+    /// `u64::MAX` means unknown; such a stream is terminated by an end of
+    /// payload marker.
+    remaining_size: u64,
+    mem_limit_kb: u32,
+    preset_dict: Option<Vec<u8>>,
+    end_reached: bool,
+    /// Set once `process()` has returned an error. A failed stream stays failed.
+    failed: bool,
+    total_in: u64,
+    total_out: u64,
+}
+
+impl LzmaStream {
+    fn with_parts(
+        state: LzmaState,
+        lz: Option<LzDecoder>,
+        lzma: Option<LzmaDecoder>,
+        accum_needed: usize,
+        remaining_size: u64,
+        mem_limit_kb: u32,
+        preset_dict: Option<&[u8]>,
+    ) -> Self {
+        Self {
+            state,
+            lz,
+            lzma,
+            rc: RangeCoderState::default(),
+            carry: [0; CARRY_CAP],
+            carry_len: 0,
+            accum: Vec::new(),
+            accum_needed,
+            remaining_size,
+            mem_limit_kb,
+            preset_dict: preset_dict.map(|dict| dict.to_vec()),
+            end_reached: false,
+            failed: false,
+            total_in: 0,
+            total_out: 0,
+        }
+    }
+
+    /// Creates a decompressor for the .lzma file format, including its 13 byte
+    /// header, with an optional memory usage limit.
+    /// - `mem_limit_kb` - memory usage limit in kibibytes (KiB). `u32::MAX` means no limit.
+    /// - `preset_dict` - preset dictionary or None to use no preset dictionary.
+    ///
+    /// The header is parsed on the first [`process()`] call, so malformed
+    /// headers and memory limit violations surface from there rather than here.
+    ///
+    /// [`process()`]: LzmaStream::process
+    pub fn new_mem_limit(mem_limit_kb: u32, preset_dict: Option<&[u8]>) -> Self {
+        Self::with_parts(
+            LzmaState::Header,
+            None,
+            None,
+            13,
+            u64::MAX,
+            mem_limit_kb,
+            preset_dict,
+        )
+    }
+
+    /// Creates a decompressor for raw LZMA data (no .lzma header) optionally
+    /// with a preset dictionary.
+    /// - `uncomp_size` - the uncompressed size of the data to be decompressed.
+    /// - `props` - the LZMA properties byte.
+    /// - `dict_size` - the LZMA dictionary size.
+    /// - `preset_dict` - preset dictionary or None to use no preset dictionary.
+    pub fn new_with_props(
+        uncomp_size: u64,
+        mut props: u8,
+        dict_size: u32,
+        preset_dict: Option<&[u8]>,
+    ) -> crate::Result<Self> {
+        if props > (4 * 5 + 4) * 9 + 8 {
+            return Err(error_invalid_input("invalid props byte"));
+        }
+        let pb = props / (9 * 5);
+        props -= pb * 9 * 5;
+        let lp = props / 9;
+        let lc = props - lp * 9;
+        if dict_size > DICT_SIZE_MAX {
+            return Err(error_invalid_input("dict size too large"));
+        }
+        Self::new(
+            uncomp_size,
+            lc as _,
+            lp as _,
+            pb as _,
+            dict_size,
+            preset_dict,
+        )
+    }
+
+    /// Creates a decompressor for raw LZMA data (no .lzma header) optionally
+    /// with a preset dictionary.
+    /// - `uncomp_size` - the uncompressed size of the data to be decompressed.
+    /// - `lc` - the number of literal context bits.
+    /// - `lp` - the number of literal position bits.
+    /// - `pb` - the number of position bits.
+    /// - `dict_size` - the LZMA dictionary size.
+    /// - `preset_dict` - preset dictionary or None to use no preset dictionary.
+    pub fn new(
+        uncomp_size: u64,
+        lc: u32,
+        lp: u32,
+        pb: u32,
+        dict_size: u32,
+        preset_dict: Option<&[u8]>,
+    ) -> crate::Result<Self> {
+        let (lz, lzma) = build_decoders(uncomp_size, lc, lp, pb, dict_size, preset_dict)?;
+        Ok(Self::with_parts(
+            LzmaState::RcInit,
+            Some(lz),
+            Some(lzma),
+            5,
+            uncomp_size,
+            u32::MAX,
+            preset_dict,
+        ))
+    }
+
+    /// Total bytes consumed from input across all `process()` calls.
+    pub fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    /// Total bytes produced to output across all `process()` calls.
+    pub fn total_out(&self) -> u64 {
+        self.total_out
+    }
+
+    /// Returns true if the LZMA stream has been fully decoded.
+    pub fn is_finished(&self) -> bool {
+        self.state == LzmaState::Finished
+    }
+
+    /// Returns true if there is decoded output waiting to be flushed.
+    pub fn has_output(&self) -> bool {
+        self.lz.as_ref().is_some_and(|lz| lz.has_output())
+    }
+
+    /// Bytes that were absorbed from the caller but turned out not to belong to
+    /// the LZMA stream.
+    ///
+    /// Only meaningful once [`Status::StreamEnd`] has been returned; before
+    /// that it is always empty. Never more than 40 bytes.
+    ///
+    /// Since `process()` always takes the whole input, a container format with
+    /// more data behind the LZMA stream gets it back as `unused_input()` plus
+    /// anything past `bytes_consumed` in the last slice it passed.
+    ///
+    /// Note that for a stream with a known uncompressed size the decoder may
+    /// consume one extra byte for the final range coder normalisation, exactly
+    /// as [`LzmaReader`] does.
+    pub fn unused_input(&self) -> &[u8] {
+        if self.state == LzmaState::Finished {
+            &self.carry[..self.carry_len]
+        } else {
+            &[]
+        }
+    }
+
+    /// Process available LZMA data from `input` into `output`.
+    pub fn process(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+    ) -> crate::Result<StreamResult> {
+        if self.failed {
+            return Err(error_invalid_data("LZMA stream already failed"));
+        }
+
+        let result = self.process_inner(input, output, action);
+        if result.is_err() {
+            self.failed = true;
+        }
+        result
+    }
+
+    fn process_inner(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+    ) -> crate::Result<StreamResult> {
+        let mut in_pos = 0;
+        let mut out_pos = 0;
+        // Set when a decode pass could make no progress at all. Without this
+        // the loop spins forever on an empty input or a full output buffer.
+        let mut stalled = false;
+
+        loop {
+            match self.state {
+                LzmaState::Finished => {
+                    return Ok(StreamResult {
+                        bytes_consumed: in_pos,
+                        bytes_produced: out_pos,
+                        status: Status::StreamEnd,
+                    });
+                }
+
+                LzmaState::Header => {
+                    if let Some(result) = self.accumulate(input, action, &mut in_pos, out_pos)? {
+                        return Ok(result);
+                    }
+                    self.parse_header()?;
+                }
+
+                LzmaState::RcInit => {
+                    if let Some(result) = self.accumulate(input, action, &mut in_pos, out_pos)? {
+                        return Ok(result);
+                    }
+                    self.init_range_coder()?;
+                }
+
+                LzmaState::Decode => {
+                    if stalled {
+                        return Ok(StreamResult {
+                            bytes_consumed: in_pos,
+                            bytes_produced: out_pos,
+                            status: Status::Ok,
+                        });
+                    }
+
+                    // A stream whose declared size is zero is already over; no
+                    // decode pass will ever set this for us.
+                    if self.remaining_size == 0 {
+                        self.end_reached = true;
+                    }
+
+                    let space = {
+                        let lz = self.lz_mut()?;
+                        lz.ensure_capacity()?;
+                        lz.available_space()
+                    };
+
+                    if self.end_reached || space == 0 {
+                        self.state = LzmaState::DrainOutput;
+                        continue;
+                    }
+
+                    let (consumed, produced) = self.decode_pass(input, &mut in_pos, action)?;
+                    if consumed == 0 && produced == 0 && !self.end_reached {
+                        stalled = true;
+                    }
+                    self.state = LzmaState::DrainOutput;
+                }
+
+                LzmaState::DrainOutput => {
+                    if out_pos >= output.len() {
+                        return Ok(StreamResult {
+                            bytes_consumed: in_pos,
+                            bytes_produced: out_pos,
+                            status: Status::Ok,
+                        });
+                    }
+
+                    let (flushed, has_output) = {
+                        let lz = self.lz_mut()?;
+                        let flushed = lz.flush_partial(&mut output[out_pos..]);
+                        (flushed, lz.has_output())
+                    };
+                    out_pos += flushed;
+                    self.total_out += flushed as u64;
+
+                    if has_output {
+                        return Ok(StreamResult {
+                            bytes_consumed: in_pos,
+                            bytes_produced: out_pos,
+                            status: Status::Ok,
+                        });
+                    }
+
+                    self.state = if self.end_reached {
+                        LzmaState::Finished
+                    } else {
+                        LzmaState::Decode
+                    };
+                }
+            }
+        }
+    }
+
+    fn lz_mut(&mut self) -> crate::Result<&mut LzDecoder> {
+        self.lz
+            .as_mut()
+            .ok_or_else(|| error_invalid_data("LZMA decoder not initialized"))
+    }
+
+    /// Fills `accum` up to `accum_needed` bytes, returning a result to hand back
+    /// to the caller when the input ran dry first.
+    fn accumulate(
+        &mut self,
+        input: &[u8],
+        action: Action,
+        in_pos: &mut usize,
+        out_pos: usize,
+    ) -> crate::Result<Option<StreamResult>> {
+        while self.accum.len() < self.accum_needed {
+            if *in_pos >= input.len() {
+                if action == Action::Finish {
+                    return Err(error_invalid_data("unexpected end of LZMA stream"));
+                }
+                return Ok(Some(StreamResult {
+                    bytes_consumed: *in_pos,
+                    bytes_produced: out_pos,
+                    status: Status::Ok,
+                }));
+            }
+            let need = self.accum_needed - self.accum.len();
+            let to_copy = need.min(input.len() - *in_pos);
+            self.accum
+                .extend_from_slice(&input[*in_pos..*in_pos + to_copy]);
+            *in_pos += to_copy;
+            self.total_in += to_copy as u64;
+        }
+        Ok(None)
+    }
+
+    /// Parses the 13 byte .lzma header: `props: u8`, `dict_size: u32` little
+    /// endian, `uncomp_size: u64` little endian. Note that LZMA2 chunk headers
+    /// are big endian; these are not.
+    fn parse_header(&mut self) -> crate::Result<()> {
+        let props = self.accum[0];
+        let dict_size =
+            u32::from_le_bytes([self.accum[1], self.accum[2], self.accum[3], self.accum[4]]);
+        let uncomp_size = u64::from_le_bytes([
+            self.accum[5],
+            self.accum[6],
+            self.accum[7],
+            self.accum[8],
+            self.accum[9],
+            self.accum[10],
+            self.accum[11],
+            self.accum[12],
+        ]);
+
+        // Check the memory limit before allocating anything.
+        let need_mem = get_memory_usage_by_props(dict_size, props)?;
+        if self.mem_limit_kb < need_mem {
+            return Err(error_out_of_memory(
+                "needed memory too big for mem_limit_kb",
+            ));
+        }
+
+        let mut props = props;
+        let pb = props / (9 * 5);
+        props -= pb * 9 * 5;
+        let lp = props / 9;
+        let lc = props - lp * 9;
+        if dict_size > DICT_SIZE_MAX {
+            return Err(error_invalid_input("dict size too large"));
+        }
+
+        let (lz, lzma) = build_decoders(
+            uncomp_size,
+            lc as _,
+            lp as _,
+            pb as _,
+            dict_size,
+            self.preset_dict.as_deref(),
+        )?;
+        self.lz = Some(lz);
+        self.lzma = Some(lzma);
+        self.remaining_size = uncomp_size;
+
+        self.accum.clear();
+        self.accum_needed = 5;
+        self.state = LzmaState::RcInit;
+        Ok(())
+    }
+
+    /// Incremental equivalent of [`RangeDecoder::new_stream`]: the first byte
+    /// must be zero, the next four are `code` in big endian order.
+    fn init_range_coder(&mut self) -> crate::Result<()> {
+        if self.accum[0] != 0x00 {
+            return Err(error_invalid_input("range decoder first byte is not zero"));
+        }
+        self.rc = RangeCoderState {
+            range: 0xFFFF_FFFF,
+            code: u32::from_be_bytes([self.accum[1], self.accum[2], self.accum[3], self.accum[4]]),
+        };
+        self.accum.clear();
+        self.accum_needed = 0;
+        self.state = LzmaState::Decode;
+        Ok(())
+    }
+
+    /// Runs one decode pass, returning `(bytes consumed from input, bytes
+    /// decoded into the dictionary)`.
+    fn decode_pass(
+        &mut self,
+        input: &[u8],
+        in_pos: &mut usize,
+        action: Action,
+    ) -> crate::Result<(usize, usize)> {
+        let mut consumed = 0;
+        let mut produced = 0;
+
+        // No more input will ever arrive, so go straight to the finish tail
+        // rather than pointlessly re-running the carry.
+        let finish_now = action == Action::Finish && *in_pos >= input.len();
+
+        // Set when the carry could not be drained. The caller's remaining input
+        // cannot be decoded in place until it has been.
+        let mut carry_blocked = false;
+
+        // Decode across the boundary between the bytes carried over from an
+        // earlier call and the fresh input.
+        if self.carry_len > 0 && !finish_now {
+            let carry_len = self.carry_len;
+            let m = (input.len() - *in_pos).min(CARRY_CAP - carry_len);
+            let filled = carry_len + m;
+
+            let mut scratch = self.carry;
+            scratch[carry_len..filled].copy_from_slice(&input[*in_pos..*in_pos + m]);
+
+            let symbol_limit = filled.saturating_sub(IN_REQUIRED - 1);
+            let (pos, decoded) = self.run(&scratch[..filled], filled, symbol_limit)?;
+            produced += decoded;
+
+            if pos >= carry_len {
+                // The carry is drained. Un-consume the scratch residue so the
+                // direct path below can pick it up in place.
+                let extra = pos - carry_len;
+                *in_pos += extra;
+                self.total_in += extra as u64;
+                consumed += extra;
+                self.carry_len = 0;
+            } else {
+                // Only reachable when `m < IN_REQUIRED`, i.e. the caller did
+                // not hand us enough to complete even one symbol. The residue
+                // can be as large as `CARRY_CAP - 1`.
+                let residue = filled - pos;
+                self.carry[..residue].copy_from_slice(&scratch[pos..filled]);
+                self.carry_len = residue;
+                *in_pos += m;
+                self.total_in += m as u64;
+                consumed += m;
+                carry_blocked = true;
+            }
+        }
+
+        // Decode in place over the caller's buffer, zero copy.
+        if !carry_blocked && !self.end_reached {
+            let avail = input.len() - *in_pos;
+            if avail >= IN_REQUIRED {
+                // A symbol may start only while `pos + IN_REQUIRED <= avail`,
+                // that is while `pos < avail - (IN_REQUIRED - 1)`.
+                let symbol_limit = avail - (IN_REQUIRED - 1);
+                let (pos, decoded) = self.run(&input[*in_pos..], avail, symbol_limit)?;
+                produced += decoded;
+                *in_pos += pos;
+                self.total_in += pos as u64;
+                consumed += pos;
+            }
+        }
+
+        // What is left is too short to start a symbol from, so take it into the
+        // carry.
+        if !carry_blocked && !self.end_reached {
+            let rest = input.len() - *in_pos;
+            if rest > 0 && rest < IN_REQUIRED {
+                debug_assert_eq!(self.carry_len, 0);
+                self.carry[..rest].copy_from_slice(&input[*in_pos..]);
+                self.carry_len = rest;
+                *in_pos = input.len();
+                self.total_in += rest as u64;
+                consumed += rest;
+            }
+        }
+
+        // Decode the carry against zero padding and require the stream to end
+        // inside the real bytes.
+        if action == Action::Finish && !self.end_reached && *in_pos >= input.len() {
+            produced += self.decode_finish_tail()?;
+        }
+
+        Ok((consumed, produced))
+    }
+
+    /// Decodes what is left of the carry with padding zeros behind it, so the
+    /// decoder still sees the 20 bytes it needs to start one more symbol.
+    ///
+    /// The carry bytes were counted as consumed when they were taken in, so this
+    /// adds nothing to `bytes_consumed`.
+    fn decode_finish_tail(&mut self) -> crate::Result<usize> {
+        if room_for(self.lz.as_ref(), self.remaining_size) == 0 {
+            // No output space, so we cannot yet tell whether the stream really
+            // ends here. The caller has to drain first.
+            return Ok(0);
+        }
+
+        let carry_len = self.carry_len;
+
+        // One symbol may start at `pos == carry_len` and read up to
+        // `IN_REQUIRED` bytes from there, so at least that many zeros follow.
+        let mut scratch = [0u8; CARRY_CAP + IN_REQUIRED + 1];
+        scratch[..carry_len].copy_from_slice(&self.carry[..carry_len]);
+        let padded_len = carry_len + IN_REQUIRED + 1;
+        let (pos, produced) = self.run(&scratch[..padded_len], carry_len, carry_len + 1)?;
+
+        if pos > carry_len {
+            // The decoder had to read padding to get here, so the input is
+            // really truncated.
+            return Err(error_invalid_data("truncated LZMA stream"));
+        }
+
+        // Padding bytes must never be written back into the carry.
+        self.carry.copy_within(pos..carry_len, 0);
+        self.carry_len = carry_len - pos;
+
+        Ok(produced)
+    }
+
+    /// Decodes as much as fits from `buf`, returning `(read position, bytes
+    /// decoded into the dictionary)`.
+    fn run(
+        &mut self,
+        buf: &[u8],
+        real_len: usize,
+        symbol_limit: usize,
+    ) -> crate::Result<(usize, usize)> {
+        // `lz` and `lzma` stay borrowed while `rc` lives, so the fields are
+        // destructured up front and the range coder state is written back in
+        // exactly one place below, error paths included.
+        let Self {
+            lz,
+            lzma,
+            rc: rc_state,
+            remaining_size,
+            end_reached,
+            ..
+        } = self;
+
+        let room = room_for(lz.as_ref(), *remaining_size);
+        if room == 0 {
+            return Ok((0, 0));
+        }
+
+        let (lz, lzma) = match (lz.as_mut(), lzma.as_mut()) {
+            (Some(lz), Some(lzma)) => (lz, lzma),
+            _ => return Err(error_invalid_data("LZMA decoder not initialized")),
+        };
+
+        let pos_before = lz.get_pos();
+        lz.set_limit(room);
+
+        let mut rc = RangeDecoder::from_parts(
+            SliceRangeReader::new(buf, real_len, symbol_limit),
+            *rc_state,
+        );
+        let decode_result = lzma.decode(lz, &mut rc);
+
+        // Must be read before anything can flush: `flush_partial` wraps `pos`
+        // back to zero once the dictionary is full and fully drained.
+        let produced = lz.get_pos() - pos_before;
+
+        let mut error = None;
+        if let Err(decode_error) = decode_result {
+            // An end of payload marker surfaces as an error, because the decoder
+            // calls `lz.repeat(0xFFFF_FFFF, len)`, which fails with "dist
+            // overflow". Anything else is genuine corruption. Check the order:
+            // `end_marker_detected()` is only meaningful right after a failed
+            // `repeat`.
+            if *remaining_size != u64::MAX || !lzma.end_marker_detected() {
+                error = Some(decode_error);
+            } else {
+                if rc.can_normalize() {
+                    rc.normalize();
+                }
+                // Only once the stream is known to end cleanly, or a caller that
+                // calls again after the error is told it did.
+                if rc.is_stream_finished() {
+                    *end_reached = true;
+                } else {
+                    error = Some(error_invalid_data("LZMA stream not properly terminated"));
+                }
+            }
+        }
+
+        // The reported position is only ever compared against buffer bounds:
+        // the assembly `decode_direct_bits` advances `pos` past what a symbol
+        // logically needed and clamps its reads instead of signalling.
+        let pos = rc.inner().pos().min(buf.len());
+        *rc_state = rc.state();
+
+        if let Some(error) = error {
+            return Err(error);
+        }
+
+        if *remaining_size <= u64::MAX / 2 {
+            *remaining_size -= produced as u64;
+            if *remaining_size == 0 {
+                *end_reached = true;
+            }
+        }
+
+        if *end_reached && lz.has_pending() {
+            return Err(error_invalid_data("end reached but not decoder finished"));
+        }
+
+        Ok((pos, produced))
+    }
+}
+
+/// Shared by both the raw constructors and the header parser. Mirrors
+/// `LzmaReader::construct2`, including the dictionary shrink for known sizes.
+fn build_decoders(
+    uncomp_size: u64,
+    lc: u32,
+    lp: u32,
+    pb: u32,
+    dict_size: u32,
+    preset_dict: Option<&[u8]>,
+) -> crate::Result<(LzDecoder, LzmaDecoder)> {
+    if lc > 8 || lp > 4 || pb > 4 {
+        return Err(error_invalid_input("invalid lc or lp or pb"));
+    }
+    let mut dict_size = get_dict_size(dict_size)?;
+
+    let preset_size = preset_dict
+        .map(|dict| dict.len().min(dict_size as usize) as u64)
+        .unwrap_or(0);
+    let min_history_size = uncomp_size.saturating_add(preset_size);
+
+    if uncomp_size <= u64::MAX / 2 && dict_size as u64 > min_history_size {
+        dict_size = get_dict_size(min_history_size as u32)?;
+    }
+
+    let lz = LzDecoder::new(get_dict_size(dict_size)? as _, preset_dict);
+    let lzma = LzmaDecoder::new(lc, lp, pb);
+    Ok((lz, lzma))
 }

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -5,8 +5,8 @@ use crate::{
     decoder::LzmaDecoder,
     error_invalid_data, error_invalid_input, error_out_of_memory,
     lz::LzDecoder,
-    lzma2_reader::{Action, Status, StreamResult},
     range_dec::{RangeCoderState, RangeDecoder, SliceRangeReader},
+    stream::{Action, Status, StreamResult},
 };
 
 /// Calculates the memory usage in KiB required for LZMA decompression from properties byte.

--- a/src/range_dec.rs
+++ b/src/range_dec.rs
@@ -52,6 +52,18 @@ impl<R: RangeReader> RangeDecoder<R> {
     pub(crate) fn is_stream_finished(&self) -> bool {
         self.code == 0
     }
+
+    /// See [`RangeReader::can_start_symbol`].
+    #[inline(always)]
+    pub(crate) fn can_start_symbol(&self) -> bool {
+        self.inner.can_start_symbol()
+    }
+
+    /// See [`RangeReader::can_normalize`].
+    #[inline(always)]
+    pub(crate) fn can_normalize(&self) -> bool {
+        self.inner.can_normalize()
+    }
 }
 
 impl<R: RangeReader> RangeDecoder<R> {
@@ -409,6 +421,25 @@ pub(crate) trait RangeReader {
     fn try_read_u8(&mut self) -> crate::Result<u8>;
 
     fn read_u32_be(&mut self) -> crate::Result<u32>;
+
+    /// True when there is enough input left to decode a whole symbol.
+    ///
+    /// Only a reader over a borrowed slice can run out in the middle of one.
+    /// Every other reader can always get another byte, so it returns a constant
+    /// `true` and the check disappears from the hot loop.
+    #[inline(always)]
+    fn can_start_symbol(&self) -> bool {
+        true
+    }
+
+    /// True when the lookahead read after the last symbol may take a byte.
+    ///
+    /// A reader over a borrowed slice says no once it has used up its input.
+    /// Every other reader always has another byte to give.
+    #[inline(always)]
+    fn can_normalize(&self) -> bool {
+        true
+    }
 
     #[inline(always)]
     fn is_buffer(&self) -> bool {

--- a/src/range_dec.rs
+++ b/src/range_dec.rs
@@ -11,7 +11,33 @@ pub(crate) struct RangeDecoder<R> {
     code: u32,
 }
 
+/// The persistent part of a range decoder: everything except the byte source.
+///
+/// A sans-I/O decoder cannot own its byte source: the input is a slice borrowed
+/// from the caller, and only for one `process()` call. Keeping `{range, code}`
+/// apart from it lets such a decoder build a fresh [`RangeDecoder`] each call.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct RangeCoderState {
+    pub(crate) range: u32,
+    pub(crate) code: u32,
+}
+
 impl<R> RangeDecoder<R> {
+    pub(crate) fn from_parts(inner: R, state: RangeCoderState) -> Self {
+        Self {
+            inner,
+            range: state.range,
+            code: state.code,
+        }
+    }
+
+    pub(crate) fn state(&self) -> RangeCoderState {
+        RangeCoderState {
+            range: self.range,
+            code: self.code,
+        }
+    }
+
     pub(crate) fn into_inner(self) -> R {
         self.inner
     }
@@ -412,6 +438,110 @@ impl RangeDecoderBuffer {
             buf: vec![0; len],
             pos: len,
         }
+    }
+}
+
+/// A [`RangeReader`] over a borrowed input slice that knows where it must stop.
+///
+/// A symbol can be up to 20 bytes long, and we can't stop decoding a symbol
+/// halfway, so we may only start while 20 bytes are left. A symbol may start
+/// only while `pos < symbol_limit`.
+///
+/// When a stream has less than 20 bytes at the end, the caller passes the last
+/// real bytes followed by padding bytes. `real_len` stores the size of actual
+/// data. If the reader reads those padding bytes, we know that the stream is
+/// truncated.
+pub(crate) struct SliceRangeReader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+    real_len: usize,
+    symbol_limit: usize,
+}
+
+impl<'a> SliceRangeReader<'a> {
+    /// `real_len` must not exceed `buf.len()`, and `symbol_limit` must leave
+    /// room for a whole symbol: the last position one may start at is
+    /// `symbol_limit - 1`, and a symbol reads up to 20 bytes, so
+    /// `symbol_limit + 19 <= buf.len()`. A `symbol_limit` of 0 is fine too and
+    /// means no symbol may start at all.
+    pub(crate) fn new(buf: &'a [u8], real_len: usize, symbol_limit: usize) -> Self {
+        debug_assert!(!buf.is_empty());
+        debug_assert!(real_len <= buf.len());
+        Self {
+            buf,
+            pos: 0,
+            real_len,
+            symbol_limit,
+        }
+    }
+
+    pub(crate) fn pos(&self) -> usize {
+        self.pos
+    }
+}
+
+impl RangeReader for SliceRangeReader<'_> {
+    #[inline(always)]
+    fn read_u8(&mut self) -> u8 {
+        // Out of bound reads return an 1, which is fine, since the
+        // LZMA reader will then throw a "dist overflow" error. With a correct
+        // `symbol_limit` this can't be reached from inside a symbol anyway.
+        let byte = *self.buf.get(self.pos).unwrap_or(&1);
+        self.pos += 1;
+        byte
+    }
+
+    fn try_read_u8(&mut self) -> crate::Result<u8> {
+        let byte = self.buf.get(self.pos).copied().ok_or_else(error_eof)?;
+        self.pos += 1;
+        Ok(byte)
+    }
+
+    #[inline(always)]
+    fn read_u32_be(&mut self) -> crate::Result<u32> {
+        let array: [u8; 4] = self
+            .buf
+            .get(self.pos..self.pos + 4)
+            .ok_or_else(|| error_invalid_data("not enough data for reading u32 BE bytes"))?
+            .try_into()
+            .map_err(|_| error_other("slice doesn't match array size for u32 BE bytes"))?;
+        self.pos += 4;
+        Ok(u32::from_be_bytes(array))
+    }
+
+    #[inline(always)]
+    fn can_start_symbol(&self) -> bool {
+        self.pos < self.symbol_limit
+    }
+
+    #[inline(always)]
+    fn can_normalize(&self) -> bool {
+        self.pos < self.real_len
+    }
+
+    #[inline(always)]
+    fn is_buffer(&self) -> bool {
+        // This check is what keeps the assembly paths safe. They compute
+        // `buf.len() - 1`, which would wrap around on an empty slice, so an
+        // empty buffer has to go down the plain Rust path instead. Do not
+        // replace this with a plain `true`: `new()` only checks for an empty
+        // buffer in debug builds.
+        !self.buf.is_empty()
+    }
+
+    #[inline(always)]
+    fn pos(&self) -> usize {
+        self.pos
+    }
+
+    #[inline(always)]
+    fn set_pos(&mut self, pos: usize) {
+        self.pos = pos;
+    }
+
+    #[inline(always)]
+    fn buf(&self) -> &[u8] {
+        self.buf
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,34 @@
+//! Types shared by every sans-I/O decoder in the crate.
+//!
+//! `LzmaStream`, `Lzma2Stream` and `XzStream` all expose the same push/pull
+//! shape: hand `process()` an input slice, an output slice and an [`Action`],
+//! and get back a [`StreamResult`].
+
+/// Action to perform during stream processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// Process available data without flushing.
+    Run,
+    /// Signal that no more input will be provided.
+    Finish,
+}
+
+/// Status returned by stream processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// More input or output space needed to continue.
+    Ok,
+    /// The stream has been fully processed.
+    StreamEnd,
+}
+
+/// Result of a single `process()` call.
+#[derive(Debug, Clone, Copy)]
+pub struct StreamResult {
+    /// Number of bytes consumed from the input buffer.
+    pub bytes_consumed: usize,
+    /// Number of bytes written to the output buffer.
+    pub bytes_produced: usize,
+    /// Current stream status.
+    pub status: Status,
+}

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -12,7 +12,8 @@ use crate::{
         bcj::{BcjFilter, BcjReader},
         delta::{Delta, DeltaReader},
     },
-    lzma2_reader::{Action, Lzma2Stream, Status, StreamResult},
+    lzma2_reader::Lzma2Stream,
+    stream::{Action, Status, StreamResult},
 };
 
 #[allow(clippy::large_enum_variant)]

--- a/tests/lzip_stream.rs
+++ b/tests/lzip_stream.rs
@@ -1,0 +1,636 @@
+use std::{
+    io::{ErrorKind, Read, Write},
+    num::NonZeroU64,
+};
+
+use lzma_rust2::{Action, LzipOptions, LzipReader, LzipStream, LzipWriter, Status};
+
+static EXECUTABLE: &str = "tests/data/executable.exe";
+static PG100: &str = "tests/data/pg100.txt";
+static PG6800: &str = "tests/data/pg6800.txt";
+static INPUT_HTML: &str = "tests/data/input.html";
+static APACHE2: &str = "tests/data/apache2.txt";
+static REFERENCE: &str = "tests/data/executable.exe.lz";
+
+/// Chunk size meaning "hand over everything that is left".
+const ENTIRE: usize = usize::MAX;
+
+const HEADER_SIZE: usize = 6;
+
+/// The 19/20/21 and 39/40/41 rows are where a finished member hands back more
+/// than the 20 byte trailer, so what it gives back reaches into the next
+/// member's header and payload.
+const CHUNK_SIZES: &[usize] = &[1, 2, 3, 5, 19, 20, 21, 39, 40, 41, 4096, ENTIRE];
+const OUTPUT_SIZES: &[usize] = &[1, 7, 4096];
+
+fn compress(data: &[u8], preset: u32, member_size: Option<u64>) -> Vec<u8> {
+    let mut options = LzipOptions::with_preset(preset);
+    options.set_member_size(member_size.and_then(NonZeroU64::new));
+    let mut writer = LzipWriter::new(Vec::new(), options);
+    writer.write_all(data).unwrap();
+    writer.finish().unwrap()
+}
+
+/// Compresses `data` in pieces and concatenates the results, which is a
+/// multi member file with members as small as we like.
+fn compress_members(data: &[u8], preset: u32, piece: usize) -> Vec<u8> {
+    let mut compressed = Vec::new();
+    for part in data.chunks(piece) {
+        compressed.extend_from_slice(&compress(part, preset, None));
+    }
+    compressed
+}
+
+/// Drives a stream to completion, feeding at most `chunk` bytes and accepting at
+/// most `out_size` bytes per call. The stream is borrowed so that a test can ask
+/// it about the file afterwards.
+fn decode(
+    stream: &mut LzipStream,
+    compressed: &[u8],
+    chunk: usize,
+    out_size: usize,
+) -> std::io::Result<Vec<u8>> {
+    let mut decompressed = Vec::new();
+    let mut output = vec![0u8; out_size];
+    let mut pos = 0usize;
+
+    loop {
+        let end = pos.saturating_add(chunk).min(compressed.len());
+        let action = if end >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+
+        let result = stream.process(&compressed[pos..end], &mut output, action)?;
+        pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+
+        if result.status == Status::StreamEnd {
+            assert!(stream.is_finished());
+            assert_eq!(stream.total_out(), decompressed.len() as u64);
+            return Ok(decompressed);
+        }
+
+        // Neither consuming nor producing anything while output space is
+        // available is a stall: the caller would loop forever.
+        assert!(
+            result.bytes_consumed != 0 || result.bytes_produced != 0,
+            "stalled at input {pos}/{} after {} bytes of output",
+            compressed.len(),
+            decompressed.len()
+        );
+    }
+}
+
+/// Same as [`decode`], for the cases that have to fail.
+fn decode_err(
+    stream: &mut LzipStream,
+    compressed: &[u8],
+    chunk: usize,
+    out_size: usize,
+) -> std::io::Error {
+    match decode(stream, compressed, chunk, out_size) {
+        Ok(decompressed) => panic!("{} bytes decoded without an error", decompressed.len()),
+        Err(error) => error,
+    }
+}
+
+/// The reference: same compressed bytes through the blocking reader.
+fn decode_with_reader(compressed: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut decompressed = Vec::new();
+    LzipReader::new(compressed).read_to_end(&mut decompressed)?;
+    Ok(decompressed)
+}
+
+fn test_round_trip(path: &str, preset: u32) {
+    let data = std::fs::read(path).unwrap();
+
+    let compressed = compress(&data, preset, None);
+    let decompressed = decode(&mut LzipStream::new(), &compressed, ENTIRE, 4096).unwrap();
+    assert!(decompressed == data, "preset {preset}");
+    assert_eq!(decompressed.len(), data.len(), "preset {preset}");
+}
+
+macro_rules! round_trip_tests {
+    ($($name:ident => ($path:expr, $preset:expr)),* $(,)?) => {
+        $(
+            #[test]
+            fn $name() {
+                test_round_trip($path, $preset);
+            }
+        )*
+    };
+}
+
+round_trip_tests! {
+    round_trip_executable_0 => (EXECUTABLE, 0),
+    round_trip_executable_1 => (EXECUTABLE, 1),
+    round_trip_executable_2 => (EXECUTABLE, 2),
+    round_trip_executable_3 => (EXECUTABLE, 3),
+    round_trip_executable_4 => (EXECUTABLE, 4),
+    round_trip_executable_5 => (EXECUTABLE, 5),
+    round_trip_executable_6 => (EXECUTABLE, 6),
+    round_trip_executable_7 => (EXECUTABLE, 7),
+    round_trip_executable_8 => (EXECUTABLE, 8),
+    round_trip_executable_9 => (EXECUTABLE, 9),
+    round_trip_pg100_0 => (PG100, 0),
+    round_trip_pg100_1 => (PG100, 1),
+    round_trip_pg100_2 => (PG100, 2),
+    round_trip_pg100_3 => (PG100, 3),
+    round_trip_pg100_4 => (PG100, 4),
+    round_trip_pg100_5 => (PG100, 5),
+    round_trip_pg100_6 => (PG100, 6),
+    round_trip_pg100_7 => (PG100, 7),
+    round_trip_pg100_8 => (PG100, 8),
+    round_trip_pg100_9 => (PG100, 9),
+    round_trip_pg6800_0 => (PG6800, 0),
+    round_trip_pg6800_1 => (PG6800, 1),
+    round_trip_pg6800_2 => (PG6800, 2),
+    round_trip_pg6800_3 => (PG6800, 3),
+    round_trip_pg6800_4 => (PG6800, 4),
+    round_trip_pg6800_5 => (PG6800, 5),
+    round_trip_pg6800_6 => (PG6800, 6),
+    round_trip_pg6800_7 => (PG6800, 7),
+    round_trip_pg6800_8 => (PG6800, 8),
+    round_trip_pg6800_9 => (PG6800, 9),
+    round_trip_input_html_0 => (INPUT_HTML, 0),
+    round_trip_input_html_1 => (INPUT_HTML, 1),
+    round_trip_input_html_2 => (INPUT_HTML, 2),
+    round_trip_input_html_3 => (INPUT_HTML, 3),
+    round_trip_input_html_4 => (INPUT_HTML, 4),
+    round_trip_input_html_5 => (INPUT_HTML, 5),
+    round_trip_input_html_6 => (INPUT_HTML, 6),
+    round_trip_input_html_7 => (INPUT_HTML, 7),
+    round_trip_input_html_8 => (INPUT_HTML, 8),
+    round_trip_input_html_9 => (INPUT_HTML, 9),
+    round_trip_apache2_0 => (APACHE2, 0),
+    round_trip_apache2_1 => (APACHE2, 1),
+    round_trip_apache2_2 => (APACHE2, 2),
+    round_trip_apache2_3 => (APACHE2, 3),
+    round_trip_apache2_4 => (APACHE2, 4),
+    round_trip_apache2_5 => (APACHE2, 5),
+    round_trip_apache2_6 => (APACHE2, 6),
+    round_trip_apache2_7 => (APACHE2, 7),
+    round_trip_apache2_8 => (APACHE2, 8),
+    round_trip_apache2_9 => (APACHE2, 9),
+}
+
+/// Members written by `LzipWriter` itself. It raises the member size to the
+/// dictionary size, so this needs an input of a few megabytes to split at all.
+#[test]
+fn writer_split_members_round_trip() {
+    let data = std::fs::read(PG100).unwrap();
+
+    for preset in [0, 1] {
+        let compressed = compress(&data, preset, Some(256 * 1024));
+        let mut stream = LzipStream::new();
+        let decompressed = decode(&mut stream, &compressed, ENTIRE, 4096).unwrap();
+
+        assert!(decompressed == data, "preset {preset}");
+        assert!(
+            stream.member_count() > 1,
+            "preset {preset} produced a single member"
+        );
+    }
+}
+
+#[test]
+fn concatenated_members_round_trip() {
+    let data = &std::fs::read(APACHE2).unwrap()[..2048];
+
+    for piece in [1usize, 7, 512, 4096] {
+        let compressed = compress_members(data, 0, piece);
+        let decompressed = decode(&mut LzipStream::new(), &compressed, 4096, 4096).unwrap();
+        assert!(decompressed == data, "piece {piece}");
+    }
+}
+
+/// Members short enough that what one of them hands back can cover the whole of
+/// the next one.
+#[test]
+fn tiny_members_decode() {
+    let compressed = compress_members(b"aaaaaaaa", 0, 1);
+
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let decompressed = decode(&mut LzipStream::new(), &compressed, chunk, out_size)
+                .unwrap_or_else(|error| panic!("chunk {chunk} out {out_size}: {error}"));
+            assert_eq!(decompressed, b"aaaaaaaa", "chunk {chunk} out {out_size}");
+        }
+    }
+}
+
+#[test]
+fn empty_members_decode() {
+    let mut compressed = Vec::new();
+    for _ in 0..8 {
+        compressed.extend_from_slice(&compress(b"", 0, None));
+    }
+
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let decompressed = decode(&mut LzipStream::new(), &compressed, chunk, out_size)
+                .unwrap_or_else(|error| panic!("chunk {chunk} out {out_size}: {error}"));
+            assert!(decompressed.is_empty(), "chunk {chunk} out {out_size}");
+        }
+    }
+
+    assert!(decode_with_reader(&compressed).unwrap().is_empty());
+}
+
+/// The file is 11 MiB compressed, so it gets the chunk sizes that matter and a
+/// single output size instead of the whole matrix. The small output buffers run
+/// against the smaller multi member files above.
+#[test]
+fn reference_file_decodes() {
+    let compressed = std::fs::read(REFERENCE).unwrap();
+    let data = std::fs::read(EXECUTABLE).unwrap();
+
+    for &chunk in &[19usize, 20, 21, 39, 40, 41, 4096, ENTIRE] {
+        let decompressed = decode(&mut LzipStream::new(), &compressed, chunk, 4096)
+            .unwrap_or_else(|error| panic!("chunk {chunk}: {error}"));
+        assert!(decompressed == data, "chunk {chunk}");
+    }
+
+    let decompressed = decode(&mut LzipStream::new(), &compressed, 41, 64).unwrap();
+    assert!(decompressed == data, "small output");
+}
+
+#[test]
+fn reference_file_has_twelve_members() {
+    let compressed = std::fs::read(REFERENCE).unwrap();
+    let mut stream = LzipStream::new();
+    decode(&mut stream, &compressed, ENTIRE, 4096).unwrap();
+
+    assert_eq!(stream.member_count(), 12);
+    assert_eq!(stream.total_in(), compressed.len() as u64);
+}
+
+fn test_chunk_matrix(compressed: &[u8], data: &[u8], label: &str) {
+    let reference = decode_with_reader(compressed).unwrap();
+    assert!(reference == data, "{label}");
+
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let decompressed = decode(&mut LzipStream::new(), compressed, chunk, out_size)
+                .unwrap_or_else(|error| panic!("{label} chunk {chunk} out {out_size}: {error}"));
+            assert!(
+                decompressed == reference,
+                "{label} chunk {chunk} out {out_size}"
+            );
+        }
+    }
+}
+
+#[test]
+fn chunk_matrix_apache2() {
+    let data = std::fs::read(APACHE2).unwrap();
+    for preset in 0..=9 {
+        test_chunk_matrix(&compress(&data, preset, None), &data, "single member");
+    }
+}
+
+#[test]
+fn chunk_matrix_input_html() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    for preset in 0..=9 {
+        test_chunk_matrix(&compress(&data, preset, None), &data, "single member");
+    }
+}
+
+/// Low presets only: every member allocates its own dictionary, and a file of
+/// hundreds of tiny members at preset 9 would allocate 64 MiB for each of them.
+#[test]
+fn chunk_matrix_multi_member() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    for preset in [0, 1] {
+        for piece in [64usize, 1024] {
+            test_chunk_matrix(
+                &compress_members(&data, preset, piece),
+                &data,
+                "multi member",
+            );
+        }
+    }
+}
+
+#[test]
+fn chunk_matrix_empty_input() {
+    for preset in 0..=9 {
+        test_chunk_matrix(&compress(&[], preset, None), &[], "empty");
+    }
+}
+
+#[test]
+fn chunk_matrix_executable_prefix() {
+    let data = std::fs::read(EXECUTABLE).unwrap();
+    let data = &data[..64 * 1024];
+    for preset in 0..=9 {
+        test_chunk_matrix(&compress(data, preset, None), data, "single member");
+    }
+    test_chunk_matrix(&compress_members(data, 0, 8192), data, "multi member");
+}
+
+#[test]
+fn matches_reader_on_corpus() {
+    for path in [EXECUTABLE, PG100, PG6800, INPUT_HTML, APACHE2] {
+        let data = std::fs::read(path).unwrap();
+        for preset in [0, 6] {
+            let compressed = compress(&data, preset, None);
+            let reference = decode_with_reader(&compressed).unwrap();
+            let decompressed = decode(&mut LzipStream::new(), &compressed, 4096, 4096).unwrap();
+            assert!(decompressed == reference, "{path} preset {preset}");
+        }
+    }
+}
+
+#[test]
+fn matches_reader_on_multi_member_files() {
+    for path in [INPUT_HTML, APACHE2] {
+        let data = std::fs::read(path).unwrap();
+        for preset in [0, 6] {
+            let compressed = compress_members(&data, preset, 1024);
+            let reference = decode_with_reader(&compressed).unwrap();
+            let decompressed = decode(&mut LzipStream::new(), &compressed, 4096, 4096).unwrap();
+            assert!(decompressed == reference, "{path} preset {preset}");
+        }
+    }
+}
+
+#[test]
+fn a_corrupted_payload_is_caught() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = compress(&data, 6, None);
+
+    // Late in the payload, clear of both the header and the trailer.
+    let mut corrupted = compressed.clone();
+    corrupted[compressed.len() - 40] ^= 0x01;
+
+    // Which check trips first depends on the target, so only the failure is
+    // asserted.
+    decode_err(&mut LzipStream::new(), &corrupted, ENTIRE, 4096);
+}
+
+#[test]
+fn tampered_trailer_fields_are_caught() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = compress(&data, 6, None);
+    let trailer = compressed.len() - 20;
+
+    for (offset, field) in [(0, "crc32"), (4, "data size"), (12, "member size")] {
+        let mut corrupted = compressed.clone();
+        corrupted[trailer + offset] ^= 0x01;
+
+        let error = decode_err(&mut LzipStream::new(), &corrupted, ENTIRE, 4096);
+        assert_eq!(error.kind(), ErrorKind::InvalidData, "tampered {field}");
+    }
+}
+
+#[test]
+fn a_corrupted_member_in_the_middle_is_caught() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress_members(&data, 0, 1024);
+    let trailer = compressed.len() / 2;
+
+    let mut corrupted = compressed.clone();
+    corrupted[trailer] ^= 0x01;
+
+    // Either the member fails to decode, or it stops early because the flipped
+    // byte no longer looks like a header. What it must not do is decode as if
+    // nothing had happened.
+    if let Ok(decompressed) = decode(&mut LzipStream::new(), &corrupted, ENTIRE, 4096) {
+        assert!(decompressed != data);
+    }
+}
+
+#[test]
+fn bit_flips_never_panic() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = compress_members(&data[..2048], 0, 512);
+
+    // Every byte, one bit each, walking the bit position along so all eight get
+    // exercised without running the full 8x matrix.
+    for index in 0..compressed.len() {
+        let mut corrupted = compressed.clone();
+        corrupted[index] ^= 1 << (index % 8);
+        let _ = decode(&mut LzipStream::new(), &corrupted, ENTIRE, 4096);
+    }
+}
+
+#[test]
+fn every_truncated_prefix_errors() {
+    let data = &std::fs::read(APACHE2).unwrap()[..4096];
+    let piece = 1024;
+
+    // Built piece by piece, so we know where every member ends.
+    let mut compressed = Vec::new();
+    let mut boundaries = Vec::new();
+    for part in data.chunks(piece) {
+        compressed.extend_from_slice(&compress(part, 0, None));
+        boundaries.push(compressed.len());
+    }
+
+    for prefix in 1..compressed.len() {
+        let result = decode(&mut LzipStream::new(), &compressed[..prefix], ENTIRE, 4096);
+
+        // A file that stops on a member boundary is complete, and so is one
+        // that stops a few bytes into the next header: too little to tell a
+        // member that never arrived from trailing data.
+        let complete = boundaries
+            .iter()
+            .position(|&end| (end..end + HEADER_SIZE).contains(&prefix));
+
+        if let Some(index) = complete {
+            let decompressed =
+                result.unwrap_or_else(|error| panic!("prefix of {prefix} bytes errored: {error}"));
+            let decoded_len = ((index + 1) * piece).min(data.len());
+            assert!(decompressed == data[..decoded_len], "prefix {prefix}");
+        } else {
+            assert!(
+                result.is_err(),
+                "prefix of {prefix}/{} bytes decoded without an error",
+                compressed.len()
+            );
+        }
+    }
+}
+
+#[test]
+fn truncation_is_detected_at_every_chunk_size() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress(&data, 6, None);
+    let truncated = &compressed[..compressed.len() - 2];
+
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let result = decode(&mut LzipStream::new(), truncated, chunk, out_size);
+            assert!(result.is_err(), "chunk {chunk} out {out_size}");
+        }
+    }
+}
+
+#[test]
+fn a_truncated_last_member_errors() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let mut compressed = compress_members(&data, 0, 1024);
+    compressed.truncate(compressed.len() - 25);
+
+    for &chunk in CHUNK_SIZES {
+        decode_err(&mut LzipStream::new(), &compressed, chunk, 4096);
+    }
+}
+
+/// Feeds `input` and returns the decoded bytes plus everything the stream did
+/// not use up.
+fn decode_recovering_tail(
+    stream: &mut LzipStream,
+    input: &[u8],
+    chunk: usize,
+) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
+    let mut decompressed = Vec::new();
+    let mut output = [0u8; 4096];
+    let mut pos = 0usize;
+
+    loop {
+        let end = pos.saturating_add(chunk).min(input.len());
+        let action = if end >= input.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+
+        let result = stream.process(&input[pos..end], &mut output, action)?;
+        pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+
+        if result.status == Status::StreamEnd {
+            // Bytes taken in but never used come first, then whatever is left
+            // of the input.
+            let mut unused = stream.unused_input().to_vec();
+            unused.extend_from_slice(&input[pos..]);
+            assert_eq!(stream.total_in(), pos as u64);
+            return Ok((decompressed, unused));
+        }
+
+        assert!(result.bytes_consumed != 0 || result.bytes_produced != 0);
+    }
+}
+
+#[test]
+fn trailing_data_is_recoverable() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let garbage: Vec<u8> = (0u8..=255).cycle().take(300).collect();
+
+    for &chunk in CHUNK_SIZES {
+        let mut input = compress_members(&data, 0, 1024);
+        input.extend_from_slice(&garbage);
+
+        let (decompressed, unused) =
+            decode_recovering_tail(&mut LzipStream::new(), &input, chunk).unwrap();
+
+        assert!(decompressed == data, "chunk {chunk}");
+        assert_eq!(unused, garbage, "chunk {chunk}");
+    }
+}
+
+/// A tail shorter than a header cannot even be told apart from a header that
+/// has not fully arrived, and has to come back just the same.
+#[test]
+fn a_short_trailing_tail_is_recoverable() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+
+    for tail_len in 1..=8 {
+        let garbage: Vec<u8> = (0..tail_len).map(|byte| byte as u8).collect();
+        for &chunk in CHUNK_SIZES {
+            let mut input = compress(&data, 0, None);
+            input.extend_from_slice(&garbage);
+
+            let (decompressed, unused) =
+                decode_recovering_tail(&mut LzipStream::new(), &input, chunk).unwrap();
+
+            assert!(decompressed == data, "tail {tail_len} chunk {chunk}");
+            assert_eq!(unused, garbage, "tail {tail_len} chunk {chunk}");
+        }
+    }
+}
+
+#[test]
+fn non_lzip_input_errors() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+
+    for &chunk in CHUNK_SIZES {
+        let error = decode_err(&mut LzipStream::new(), &data, chunk, 4096);
+        assert_eq!(error.kind(), ErrorKind::InvalidData, "chunk {chunk}");
+    }
+}
+
+#[test]
+fn empty_input_errors() {
+    let mut stream = LzipStream::new();
+    let mut output = [0u8; 64];
+    let error = stream
+        .process(&[], &mut output, Action::Finish)
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidData);
+}
+
+#[test]
+fn empty_input_asks_for_more() {
+    let mut stream = LzipStream::new();
+    let mut output = [0u8; 64];
+    let result = stream.process(&[], &mut output, Action::Run).unwrap();
+
+    assert_eq!(result.status, Status::Ok);
+    assert_eq!(result.bytes_consumed, 0);
+    assert_eq!(result.bytes_produced, 0);
+    assert!(!stream.is_finished());
+}
+
+/// Memory a member with the given dictionary size needs, in KiB. LZIP fixes
+/// lc=3 and lp=0.
+fn member_memory(dict_size: u32) -> u32 {
+    lzma_rust2::lzma_get_memory_usage(dict_size, 3, 0).unwrap()
+}
+
+#[test]
+fn memory_limit_is_enforced_from_process() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress(&data, 9, None);
+
+    // The constructor cannot fail; the limit is checked once a member header
+    // has been parsed.
+    let mut stream = LzipStream::new_mem_limit(1);
+    let mut output = [0u8; 4096];
+    let error = stream
+        .process(&compressed, &mut output, Action::Finish)
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::OutOfMemory);
+
+    // A generous limit works on the same bytes.
+    let decompressed = decode(&mut LzipStream::new(), &compressed, ENTIRE, 4096).unwrap();
+    assert!(decompressed == data);
+}
+
+#[test]
+fn memory_limit_is_enforced_when_the_header_arrives_byte_by_byte() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress(&data, 9, None);
+    let result = decode(&mut LzipStream::new_mem_limit(1), &compressed, 1, 4096);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::OutOfMemory);
+}
+
+#[test]
+fn memory_limit_is_enforced_on_a_later_member() {
+    let data = std::fs::read(APACHE2).unwrap();
+
+    // Preset 0 uses a 256 KiB dictionary, preset 9 a 64 MiB one.
+    let mut input = compress(&data, 0, None);
+    let limit = member_memory(1 << 18);
+    let decompressed = decode(&mut LzipStream::new_mem_limit(limit), &input, ENTIRE, 4096).unwrap();
+    assert!(decompressed == data);
+
+    input.extend_from_slice(&compress(&data, 9, None));
+    let error = decode_err(&mut LzipStream::new_mem_limit(limit), &input, ENTIRE, 4096);
+    assert_eq!(error.kind(), ErrorKind::OutOfMemory);
+}

--- a/tests/lzma_stream.rs
+++ b/tests/lzma_stream.rs
@@ -1,0 +1,715 @@
+use std::io::{ErrorKind, Read, Write};
+
+use lzma_rust2::{Action, LzmaOptions, LzmaReader, LzmaStream, LzmaWriter, Status};
+
+static EXECUTABLE: &str = "tests/data/executable.exe";
+static PG100: &str = "tests/data/pg100.txt";
+static PG6800: &str = "tests/data/pg6800.txt";
+static INPUT_HTML: &str = "tests/data/input.html";
+static APACHE2: &str = "tests/data/apache2.txt";
+
+/// Chunk size meaning "hand over everything that is left".
+const ENTIRE: usize = usize::MAX;
+
+/// Everything the decoder needs to know about a raw (headerless) stream.
+#[derive(Clone, Copy)]
+struct RawProps {
+    uncomp_size: u64,
+    props: u8,
+    dict_size: u32,
+}
+
+fn compress_header(data: &[u8], preset: u32, known_size: bool) -> Vec<u8> {
+    let options = LzmaOptions::with_preset(preset);
+    let size = known_size.then_some(data.len() as u64);
+    let mut writer = LzmaWriter::new_use_header(Vec::new(), &options, size).unwrap();
+    writer.write_all(data).unwrap();
+    writer.finish().unwrap()
+}
+
+fn compress_raw(data: &[u8], preset: u32, use_end_marker: bool) -> (Vec<u8>, RawProps) {
+    let options = LzmaOptions::with_preset(preset);
+    let mut writer = LzmaWriter::new_no_header(Vec::new(), &options, use_end_marker).unwrap();
+    let props = writer.props();
+    writer.write_all(data).unwrap();
+    let compressed = writer.finish().unwrap();
+    (
+        compressed,
+        RawProps {
+            uncomp_size: if use_end_marker {
+                u64::MAX
+            } else {
+                data.len() as u64
+            },
+            props,
+            dict_size: options.dict_size,
+        },
+    )
+}
+
+fn raw_stream(raw: RawProps) -> LzmaStream {
+    LzmaStream::new_with_props(raw.uncomp_size, raw.props, raw.dict_size, None).unwrap()
+}
+
+/// Drives a stream to completion, feeding at most `chunk` bytes and accepting at
+/// most `out_size` bytes per call.
+fn decode(
+    mut stream: LzmaStream,
+    compressed: &[u8],
+    chunk: usize,
+    out_size: usize,
+) -> std::io::Result<Vec<u8>> {
+    let mut decompressed = Vec::new();
+    let mut output = vec![0u8; out_size];
+    let mut pos = 0usize;
+
+    loop {
+        let end = pos.saturating_add(chunk).min(compressed.len());
+        let action = if end >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+
+        let result = stream.process(&compressed[pos..end], &mut output, action)?;
+        pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+
+        if result.status == Status::StreamEnd {
+            assert!(stream.is_finished());
+            assert_eq!(stream.total_out(), decompressed.len() as u64);
+            return Ok(decompressed);
+        }
+
+        // Neither consuming nor producing anything while output space is
+        // available is a stall: the caller would loop forever.
+        assert!(
+            result.bytes_consumed != 0 || result.bytes_produced != 0,
+            "stalled at input {pos}/{} after {} bytes of output",
+            compressed.len(),
+            decompressed.len()
+        );
+    }
+}
+
+/// The reference: same compressed bytes through the blocking reader.
+fn decode_with_reader(compressed: &[u8], raw: Option<RawProps>) -> std::io::Result<Vec<u8>> {
+    let mut decompressed = Vec::new();
+    match raw {
+        None => {
+            LzmaReader::new_mem_limit(compressed, u32::MAX, None)?.read_to_end(&mut decompressed)?
+        }
+        Some(raw) => {
+            LzmaReader::new_with_props(compressed, raw.uncomp_size, raw.props, raw.dict_size, None)?
+                .read_to_end(&mut decompressed)?
+        }
+    };
+    Ok(decompressed)
+}
+
+fn test_round_trip(path: &str, preset: u32) {
+    let data = std::fs::read(path).unwrap();
+
+    // .lzma header, known uncompressed size.
+    let compressed = compress_header(&data, preset, true);
+    let decompressed = decode(
+        LzmaStream::new_mem_limit(u32::MAX, None),
+        &compressed,
+        ENTIRE,
+        4096,
+    )
+    .unwrap();
+    assert!(decompressed == data, "header/known size, preset {preset}");
+
+    // .lzma header, unknown size, terminated by an end of payload marker.
+    let compressed = compress_header(&data, preset, false);
+    let decompressed = decode(
+        LzmaStream::new_mem_limit(u32::MAX, None),
+        &compressed,
+        ENTIRE,
+        4096,
+    )
+    .unwrap();
+    assert!(decompressed == data, "header/EOPM, preset {preset}");
+
+    // Raw LZMA1 with an end of payload marker.
+    let (compressed, raw) = compress_raw(&data, preset, true);
+    let decompressed = decode(raw_stream(raw), &compressed, ENTIRE, 4096).unwrap();
+    assert!(decompressed == data, "raw/EOPM, preset {preset}");
+
+    // Raw LZMA1 with a known size and no marker.
+    let (compressed, raw) = compress_raw(&data, preset, false);
+    let decompressed = decode(raw_stream(raw), &compressed, ENTIRE, 4096).unwrap();
+    assert!(decompressed == data, "raw/known size, preset {preset}");
+}
+
+macro_rules! round_trip_tests {
+    ($($name:ident => ($path:expr, $preset:expr)),* $(,)?) => {
+        $(
+            #[test]
+            fn $name() {
+                test_round_trip($path, $preset);
+            }
+        )*
+    };
+}
+
+round_trip_tests! {
+    round_trip_executable_0 => (EXECUTABLE, 0),
+    round_trip_executable_1 => (EXECUTABLE, 1),
+    round_trip_executable_2 => (EXECUTABLE, 2),
+    round_trip_executable_3 => (EXECUTABLE, 3),
+    round_trip_executable_4 => (EXECUTABLE, 4),
+    round_trip_executable_5 => (EXECUTABLE, 5),
+    round_trip_executable_6 => (EXECUTABLE, 6),
+    round_trip_executable_7 => (EXECUTABLE, 7),
+    round_trip_executable_8 => (EXECUTABLE, 8),
+    round_trip_executable_9 => (EXECUTABLE, 9),
+    round_trip_pg100_0 => (PG100, 0),
+    round_trip_pg100_1 => (PG100, 1),
+    round_trip_pg100_2 => (PG100, 2),
+    round_trip_pg100_3 => (PG100, 3),
+    round_trip_pg100_4 => (PG100, 4),
+    round_trip_pg100_5 => (PG100, 5),
+    round_trip_pg100_6 => (PG100, 6),
+    round_trip_pg100_7 => (PG100, 7),
+    round_trip_pg100_8 => (PG100, 8),
+    round_trip_pg100_9 => (PG100, 9),
+    round_trip_pg6800_0 => (PG6800, 0),
+    round_trip_pg6800_1 => (PG6800, 1),
+    round_trip_pg6800_2 => (PG6800, 2),
+    round_trip_pg6800_3 => (PG6800, 3),
+    round_trip_pg6800_4 => (PG6800, 4),
+    round_trip_pg6800_5 => (PG6800, 5),
+    round_trip_pg6800_6 => (PG6800, 6),
+    round_trip_pg6800_7 => (PG6800, 7),
+    round_trip_pg6800_8 => (PG6800, 8),
+    round_trip_pg6800_9 => (PG6800, 9),
+    round_trip_input_html_0 => (INPUT_HTML, 0),
+    round_trip_input_html_1 => (INPUT_HTML, 1),
+    round_trip_input_html_2 => (INPUT_HTML, 2),
+    round_trip_input_html_3 => (INPUT_HTML, 3),
+    round_trip_input_html_4 => (INPUT_HTML, 4),
+    round_trip_input_html_5 => (INPUT_HTML, 5),
+    round_trip_input_html_6 => (INPUT_HTML, 6),
+    round_trip_input_html_7 => (INPUT_HTML, 7),
+    round_trip_input_html_8 => (INPUT_HTML, 8),
+    round_trip_input_html_9 => (INPUT_HTML, 9),
+    round_trip_apache2_0 => (APACHE2, 0),
+    round_trip_apache2_1 => (APACHE2, 1),
+    round_trip_apache2_2 => (APACHE2, 2),
+    round_trip_apache2_3 => (APACHE2, 3),
+    round_trip_apache2_4 => (APACHE2, 4),
+    round_trip_apache2_5 => (APACHE2, 5),
+    round_trip_apache2_6 => (APACHE2, 6),
+    round_trip_apache2_7 => (APACHE2, 7),
+    round_trip_apache2_8 => (APACHE2, 8),
+    round_trip_apache2_9 => (APACHE2, 9),
+}
+
+/// The 19/20/21 rows straddle `IN_REQUIRED`, the 39/40/41 rows straddle the
+/// carry capacity. Those are the sizes where the carry logic actually changes
+/// behaviour.
+const CHUNK_SIZES: &[usize] = &[1, 2, 3, 5, 19, 20, 21, 39, 40, 41, 4096, ENTIRE];
+const OUTPUT_SIZES: &[usize] = &[1, 7, 4096];
+
+fn test_chunk_matrix(data: &[u8], preset: u32) {
+    // Header mode, known size.
+    let compressed = compress_header(data, preset, true);
+    let reference = decode_with_reader(&compressed, None).unwrap();
+    assert!(reference == data);
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let decompressed = decode(
+                LzmaStream::new_mem_limit(u32::MAX, None),
+                &compressed,
+                chunk,
+                out_size,
+            )
+            .unwrap_or_else(|error| panic!("header chunk {chunk} out {out_size}: {error}"));
+            assert!(
+                decompressed == reference,
+                "header chunk {chunk} out {out_size}"
+            );
+        }
+    }
+
+    // Raw mode with an end of payload marker, so the EOPM path gets the same
+    // treatment.
+    let (compressed, raw) = compress_raw(data, preset, true);
+    let reference = decode_with_reader(&compressed, Some(raw)).unwrap();
+    assert!(reference == data);
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let decompressed = decode(raw_stream(raw), &compressed, chunk, out_size)
+                .unwrap_or_else(|error| panic!("raw chunk {chunk} out {out_size}: {error}"));
+            assert!(
+                decompressed == reference,
+                "raw chunk {chunk} out {out_size}"
+            );
+        }
+    }
+}
+
+#[test]
+fn chunk_matrix_apache2() {
+    let data = std::fs::read(APACHE2).unwrap();
+    for preset in 0..=9 {
+        test_chunk_matrix(&data, preset);
+    }
+}
+
+#[test]
+fn chunk_matrix_input_html() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    for preset in 0..=9 {
+        test_chunk_matrix(&data, preset);
+    }
+}
+
+/// A 64 KiB prefix is long enough to wrap the small dictionaries of the low
+/// presets, which is what exercises `flush_partial` wrapping `pos` back to 0.
+#[test]
+fn chunk_matrix_pg100_prefix() {
+    let data = std::fs::read(PG100).unwrap();
+    for preset in 0..=9 {
+        test_chunk_matrix(&data[..64 * 1024], preset);
+    }
+}
+
+#[test]
+fn chunk_matrix_executable_prefix() {
+    let data = std::fs::read(EXECUTABLE).unwrap();
+    for preset in 0..=9 {
+        test_chunk_matrix(&data[..64 * 1024], preset);
+    }
+}
+
+#[test]
+fn chunk_matrix_empty_input() {
+    for preset in 0..=9 {
+        test_chunk_matrix(&[], preset);
+    }
+}
+
+/// The margin and carry capacity edges against the whole corpus, at full size.
+/// Too slow for the default run, but it does finish in a few minutes.
+#[test]
+#[ignore = "slow: full corpus against the carry boundary chunk sizes"]
+fn chunk_boundaries_on_the_full_corpus() {
+    for path in [EXECUTABLE, PG100, PG6800, INPUT_HTML, APACHE2] {
+        let data = std::fs::read(path).unwrap();
+        for preset in [0, 6, 9] {
+            let compressed = compress_header(&data, preset, true);
+            let (raw_compressed, raw) = compress_raw(&data, preset, true);
+            for &chunk in &[19usize, 20, 21, 39, 40, 41] {
+                let decompressed = decode(
+                    LzmaStream::new_mem_limit(u32::MAX, None),
+                    &compressed,
+                    chunk,
+                    4096,
+                )
+                .unwrap_or_else(|error| panic!("{path} preset {preset} chunk {chunk}: {error}"));
+                assert!(decompressed == data, "{path} preset {preset} chunk {chunk}");
+
+                let decompressed = decode(raw_stream(raw), &raw_compressed, chunk, 4096)
+                    .unwrap_or_else(|error| {
+                        panic!("{path} preset {preset} chunk {chunk} raw: {error}")
+                    });
+                assert!(
+                    decompressed == data,
+                    "{path} preset {preset} chunk {chunk} raw"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn matches_reader_on_corpus() {
+    for path in [EXECUTABLE, PG100, PG6800, INPUT_HTML, APACHE2] {
+        let data = std::fs::read(path).unwrap();
+        for preset in [0, 6, 9] {
+            let compressed = compress_header(&data, preset, true);
+            let reference = decode_with_reader(&compressed, None).unwrap();
+            let decompressed = decode(
+                LzmaStream::new_mem_limit(u32::MAX, None),
+                &compressed,
+                4096,
+                4096,
+            )
+            .unwrap();
+            assert!(decompressed == reference, "{path} preset {preset}");
+
+            let (compressed, raw) = compress_raw(&data, preset, true);
+            let reference = decode_with_reader(&compressed, Some(raw)).unwrap();
+            let decompressed = decode(raw_stream(raw), &compressed, 4096, 4096).unwrap();
+            assert!(decompressed == reference, "{path} preset {preset} raw");
+        }
+    }
+}
+
+#[test]
+fn preset_dict_round_trip() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let preset_dict = data[..2048].to_vec();
+
+    for preset in 0..=9 {
+        for use_end_marker in [false, true] {
+            let mut options = LzmaOptions::with_preset(preset);
+            options.preset_dict = Some(preset_dict.clone());
+
+            let mut writer =
+                LzmaWriter::new_no_header(Vec::new(), &options, use_end_marker).unwrap();
+            let props = writer.props();
+            writer.write_all(&data).unwrap();
+            let compressed = writer.finish().unwrap();
+
+            let uncomp_size = if use_end_marker {
+                u64::MAX
+            } else {
+                data.len() as u64
+            };
+
+            for &chunk in CHUNK_SIZES {
+                let stream = LzmaStream::new_with_props(
+                    uncomp_size,
+                    props,
+                    options.dict_size,
+                    Some(&preset_dict),
+                )
+                .unwrap();
+                let decompressed = decode(stream, &compressed, chunk, 4096).unwrap();
+                assert!(
+                    decompressed == data,
+                    "preset {preset} eopm {use_end_marker} chunk {chunk}"
+                );
+            }
+        }
+    }
+}
+
+/// Every prefix of a valid stream must be rejected, with one unavoidable
+/// exception: the final byte of the range coder flush carries no information the
+/// decoder ever reads back, so dropping just that one byte is undetectable. It
+/// is however harmless, because the output is still complete and correct;
+/// `LzmaReader` accepts the same prefix. Anything shorter must error.
+fn assert_truncation_errors(compressed: &[u8], data: &[u8], make: impl Fn() -> LzmaStream) {
+    for prefix in 0..compressed.len() {
+        let result = decode(make(), &compressed[..prefix], ENTIRE, 4096);
+        if prefix == compressed.len() - 1 {
+            if let Ok(decompressed) = result {
+                assert!(
+                    decompressed == data,
+                    "dropping the last byte silently changed the output"
+                );
+            }
+            continue;
+        }
+        assert!(
+            result.is_err(),
+            "prefix of {prefix}/{} bytes decoded without error",
+            compressed.len()
+        );
+    }
+}
+
+#[test]
+fn truncated_header_stream_errors() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = compress_header(&data, 1, true);
+    assert_truncation_errors(&compressed, &data, || {
+        LzmaStream::new_mem_limit(u32::MAX, None)
+    });
+}
+
+#[test]
+fn truncated_eopm_stream_errors() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = compress_header(&data, 1, false);
+    assert_truncation_errors(&compressed, &data, || {
+        LzmaStream::new_mem_limit(u32::MAX, None)
+    });
+}
+
+#[test]
+fn truncated_raw_stream_errors() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (compressed, raw) = compress_raw(&data, 1, true);
+    assert_truncation_errors(&compressed, &data, || raw_stream(raw));
+}
+
+#[test]
+fn truncation_is_detected_at_every_chunk_size() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress_header(&data, 6, true);
+    let truncated = &compressed[..compressed.len() - 2];
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let result = decode(
+                LzmaStream::new_mem_limit(u32::MAX, None),
+                truncated,
+                chunk,
+                out_size,
+            );
+            assert!(result.is_err(), "chunk {chunk} out {out_size}");
+        }
+    }
+}
+
+#[test]
+fn bit_flips_never_panic() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = compress_header(&data, 1, true);
+
+    // Every byte, one bit each, walking the bit position along so all eight get
+    // exercised without running the full 8x matrix.
+    for index in 0..compressed.len() {
+        let mut corrupted = compressed.clone();
+        corrupted[index] ^= 1 << (index % 8);
+
+        for &out_size in OUTPUT_SIZES {
+            // Decoding may legitimately succeed with different data, the format
+            // has no integrity check of its own. It must not panic or stall.
+            let _ = decode(
+                LzmaStream::new_mem_limit(u32::MAX, None),
+                &corrupted,
+                ENTIRE,
+                out_size,
+            );
+        }
+    }
+}
+
+#[test]
+fn truncated_and_corrupted_never_panics() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let (compressed, raw) = compress_raw(&data, 3, true);
+
+    for index in (0..compressed.len()).step_by(7) {
+        let mut corrupted = compressed[..compressed.len() - index / 2].to_vec();
+        if index < corrupted.len() {
+            corrupted[index] ^= 0x80;
+        }
+        for &chunk in &[1usize, 20, 40, ENTIRE] {
+            let _ = decode(raw_stream(raw), &corrupted, chunk, 4096);
+        }
+    }
+}
+
+#[test]
+fn memory_limit_is_enforced_from_process() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress_header(&data, 9, true);
+
+    // The constructor cannot fail; the limit is checked once the header has
+    // been parsed.
+    let mut stream = LzmaStream::new_mem_limit(1, None);
+    let mut output = [0u8; 4096];
+    let error = stream
+        .process(&compressed, &mut output, Action::Finish)
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::OutOfMemory);
+
+    // A generous limit works on the same bytes.
+    let decompressed = decode(
+        LzmaStream::new_mem_limit(u32::MAX, None),
+        &compressed,
+        ENTIRE,
+        4096,
+    )
+    .unwrap();
+    assert!(decompressed == data);
+}
+
+#[test]
+fn memory_limit_is_enforced_when_the_header_arrives_byte_by_byte() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress_header(&data, 9, true);
+    let result = decode(LzmaStream::new_mem_limit(1, None), &compressed, 1, 4096);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::OutOfMemory);
+}
+
+/// Feeds `input` and returns the decoded bytes plus everything the stream did
+/// not use up.
+fn decode_recovering_tail(
+    mut stream: LzmaStream,
+    input: &[u8],
+    chunk: usize,
+) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
+    let mut decompressed = Vec::new();
+    let mut output = [0u8; 4096];
+    let mut pos = 0usize;
+
+    loop {
+        let end = pos.saturating_add(chunk).min(input.len());
+        let action = if end >= input.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+
+        let result = stream.process(&input[pos..end], &mut output, action)?;
+        let presented_end = end;
+        pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+
+        if result.status == Status::StreamEnd {
+            // Bytes taken into the carry but never decoded come first, then
+            // whatever is left of the slice we last presented.
+            let mut unused = stream.unused_input().to_vec();
+            unused.extend_from_slice(&input[pos..presented_end]);
+            unused.extend_from_slice(&input[presented_end..]);
+            return Ok((decompressed, unused));
+        }
+
+        assert!(result.bytes_consumed != 0 || result.bytes_produced != 0);
+    }
+}
+
+#[test]
+fn trailing_data_is_recoverable() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let garbage: Vec<u8> = (0u8..=255).cycle().take(300).collect();
+
+    for &chunk in CHUNK_SIZES {
+        let compressed = compress_header(&data, 6, true);
+        let mut input = compressed.clone();
+        input.extend_from_slice(&garbage);
+
+        let (decompressed, unused) =
+            decode_recovering_tail(LzmaStream::new_mem_limit(u32::MAX, None), &input, chunk)
+                .unwrap();
+
+        assert!(decompressed == data, "chunk {chunk}");
+        assert_eq!(unused, garbage, "chunk {chunk}");
+    }
+}
+
+#[test]
+fn trailing_data_is_recoverable_after_an_eopm_stream() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let garbage: Vec<u8> = (0u8..=255).cycle().take(300).collect();
+
+    for &chunk in CHUNK_SIZES {
+        let (compressed, raw) = compress_raw(&data, 6, true);
+        let mut input = compressed.clone();
+        input.extend_from_slice(&garbage);
+
+        let (decompressed, unused) =
+            decode_recovering_tail(raw_stream(raw), &input, chunk).unwrap();
+
+        assert!(decompressed == data, "chunk {chunk}");
+        assert_eq!(unused, garbage, "chunk {chunk}");
+    }
+}
+
+#[test]
+fn empty_input_with_finish_is_a_legal_call() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress_header(&data, 6, true);
+
+    let mut stream = LzmaStream::new_mem_limit(u32::MAX, None);
+    let mut output = [0u8; 4096];
+    let mut decompressed = Vec::new();
+    let mut pos = 0usize;
+
+    loop {
+        // Alternate between handing over real bytes and an empty flush call.
+        let end = (pos + 128).min(compressed.len());
+        let result = stream
+            .process(&compressed[pos..end], &mut output, Action::Run)
+            .unwrap();
+        pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+
+        let result = stream.process(&[], &mut output, Action::Run).unwrap();
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+        assert_eq!(result.bytes_consumed, 0);
+
+        if pos >= compressed.len() {
+            break;
+        }
+    }
+
+    loop {
+        let result = stream.process(&[], &mut output, Action::Finish).unwrap();
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    assert!(decompressed == data);
+}
+
+#[test]
+fn process_after_stream_end_keeps_reporting_stream_end() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let compressed = compress_header(&data, 6, true);
+
+    let mut stream = LzmaStream::new_mem_limit(u32::MAX, None);
+    let mut output = vec![0u8; data.len() + 1024];
+    let result = stream
+        .process(&compressed, &mut output, Action::Finish)
+        .unwrap();
+    assert_eq!(result.status, Status::StreamEnd);
+    assert!(output[..result.bytes_produced] == data[..]);
+
+    for _ in 0..3 {
+        let result = stream.process(&[], &mut output, Action::Finish).unwrap();
+        assert_eq!(result.status, Status::StreamEnd);
+        assert_eq!(result.bytes_consumed, 0);
+        assert_eq!(result.bytes_produced, 0);
+    }
+}
+
+#[test]
+fn totals_are_accurate() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress_header(&data, 6, true);
+
+    let mut stream = LzmaStream::new_mem_limit(u32::MAX, None);
+    let mut output = [0u8; 64];
+    let mut pos = 0usize;
+    let mut produced_total = 0u64;
+
+    loop {
+        let end = (pos + 13).min(compressed.len());
+        let action = if end >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = stream
+            .process(&compressed[pos..end], &mut output, action)
+            .unwrap();
+        pos += result.bytes_consumed;
+        produced_total += result.bytes_produced as u64;
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    assert_eq!(stream.total_in(), pos as u64);
+    assert_eq!(stream.total_out(), produced_total);
+    assert_eq!(produced_total, data.len() as u64);
+    assert!(!stream.has_output());
+}
+
+#[test]
+fn invalid_props_are_rejected_by_the_constructor() {
+    assert!(LzmaStream::new_with_props(0, 255, 1 << 20, None).is_err());
+    assert!(LzmaStream::new(0, 9, 0, 2, 1 << 20, None).is_err());
+    assert!(LzmaStream::new(0, 3, 5, 2, 1 << 20, None).is_err());
+    assert!(LzmaStream::new(0, 3, 0, 5, 1 << 20, None).is_err());
+}
+
+#[test]
+fn a_non_zero_first_range_coder_byte_is_rejected() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (mut compressed, raw) = compress_raw(&data, 1, true);
+    compressed[0] = 0x01;
+    let error = decode(raw_stream(raw), &compressed, ENTIRE, 4096).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidInput);
+}


### PR DESCRIPTION
The maximum input needed to safely decode one LZMA symbol is 20 bytes, as the worst case is that we decode 22 bits using probabilities and 26 direct bits. We could cache the input in an internal buffer and and only decode once enough data has been collected, to implement a new streaming API for lzma.

Changes:
- Add `LzmaStream`, a new sans-I/O decoder for lzma, similar to `XzStream` and `Lzma2Stream`. 
- Add `LzipStream`, a  new sans-I/O decoder for lzip, built on top of `LzmaStream`.
- Unit tests and fuzz targets for the 2 new API.