### PR TITLE
Make Lzma2Stream work with LzmaStream's core & minor utility changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add `new_mem_limit()` to `Lzma2Stream` and `XzStream`.
+
+### Changed
+
+- Decode LZMA2 chunks as they arrive instead of buffering each one, so `Lzma2Stream` and `XzStream` produce output sooner and use less memory.
+
+### Fixed
+
+- `Lzma2Stream` and `XzStream` now fail every later `process()` call once one has returned an error, like `LzmaStream` already did.
+
 ## 0.19.0 - 2026-08-16
 
 - Add sans-I/O decoders for LZMA1 and LZIP. Thanks @Black-Frost (#109)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `new_mem_limit()` to `Lzma2Stream` and `XzStream`.
+- Add `set_filters()` to `Lzma2Stream` and `LzmaStream`, so both can decode through a BCJ or delta pre-filter. At most one filter is supported.
+- Add `filter::StreamFilter`, which decodes a slice in place through a single BCJ or delta filter.
 
 ### Changed
 
 - Decode LZMA2 chunks as they arrive instead of buffering each one, so `Lzma2Stream` and `XzStream` produce output sooner and use less memory.
 - A truncated stream now comes back as `UnexpectedEof` from the sans-I/O decoders instead of `InvalidData`.
+- `FilterConfig` and `FilterType` no longer need the `xz` feature.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Decode LZMA2 chunks as they arrive instead of buffering each one, so `Lzma2Stream` and `XzStream` produce output sooner and use less memory.
+- A truncated stream now comes back as `UnexpectedEof` from the sans-I/O decoders instead of `InvalidData`.
 
 ### Fixed
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -4,6 +4,13 @@ pub mod bcj;
 pub mod bcj2;
 pub mod delta;
 
+use alloc::boxed::Box;
+
+use crate::{
+    error_unsupported,
+    filter::{bcj::BcjFilter, delta::Delta},
+};
+
 /// Configuration for a filter in the XZ filter chain.
 #[derive(Debug, Clone)]
 pub struct FilterConfig {
@@ -129,5 +136,82 @@ impl TryFrom<u64> for FilterType {
             0x21 => Ok(FilterType::Lzma2),
             _ => Err(()),
         }
+    }
+}
+
+/// A single filter for the sans-I/O decoders.
+///
+/// Decodes a slice in place. A BCJ filter can not classify the last bytes of a
+/// slice before it knows what follows them, so it holds them back until more
+/// data arrives or the stream ends.
+pub struct StreamFilter {
+    filter: Filter,
+    held_back: usize,
+}
+
+enum Filter {
+    Delta(Box<Delta>),
+    Bcj(BcjFilter),
+}
+
+impl StreamFilter {
+    /// Creates a new filter from its configuration.
+    ///
+    /// LZMA2 is not supported, as it is not a filter that decodes a slice in
+    /// place.
+    pub fn new(config: &FilterConfig) -> crate::Result<Self> {
+        let property = config.property as usize;
+
+        let filter = match config.filter_type {
+            FilterType::Delta => Filter::Delta(Box::new(Delta::new(property))),
+            FilterType::BcjX86 => Filter::Bcj(BcjFilter::new_x86(property, false)),
+            FilterType::BcjPpc => Filter::Bcj(BcjFilter::new_power_pc(property, false)),
+            FilterType::BcjIa64 => Filter::Bcj(BcjFilter::new_ia64(property, false)),
+            FilterType::BcjArm => Filter::Bcj(BcjFilter::new_arm(property, false)),
+            FilterType::BcjArmThumb => Filter::Bcj(BcjFilter::new_arm_thumb(property, false)),
+            FilterType::BcjSparc => Filter::Bcj(BcjFilter::new_sparc(property, false)),
+            FilterType::BcjArm64 => Filter::Bcj(BcjFilter::new_arm64(property, false)),
+            FilterType::BcjRiscv => Filter::Bcj(BcjFilter::new_riscv(property, false)),
+            FilterType::Lzma2 => {
+                return Err(error_unsupported("LZMA2 is not supported as a filter"));
+            }
+        };
+
+        Ok(Self {
+            filter,
+            held_back: 0,
+        })
+    }
+
+    /// Decodes `buf` in place and returns how many bytes at its start are
+    /// settled.
+    ///
+    /// The bytes after that are held back and have to be passed in again
+    /// together with the data that follows them.
+    pub fn decode(&mut self, buf: &mut [u8]) -> usize {
+        let decoded = match &mut self.filter {
+            Filter::Delta(delta) => {
+                delta.decode(buf);
+                buf.len()
+            }
+            Filter::Bcj(bcj) => bcj.code(buf),
+        };
+
+        self.held_back = buf.len() - decoded;
+        decoded
+    }
+
+    /// Returns how many bytes at the end of the last [`Self::decode`] are held
+    /// back.
+    pub fn held_back(&self) -> usize {
+        self.held_back
+    }
+
+    /// Settles the held back bytes at the end of the stream.
+    ///
+    /// Nothing follows them anymore, so they are used as they are and
+    /// [`Self::held_back`] returns zero afterwards.
+    pub fn finish(&mut self) {
+        self.held_back = 0;
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,3 +3,131 @@
 pub mod bcj;
 pub mod bcj2;
 pub mod delta;
+
+/// Configuration for a filter in the XZ filter chain.
+#[derive(Debug, Clone)]
+pub struct FilterConfig {
+    /// Filter type to use.
+    pub filter_type: FilterType,
+    /// Property to use.
+    pub property: u32,
+}
+
+impl FilterConfig {
+    /// Creates a new delta filter configuration.
+    pub fn new_delta(distance: u32) -> Self {
+        Self {
+            filter_type: FilterType::Delta,
+            property: distance,
+        }
+    }
+
+    /// Creates a new BCJ x86 filter configuration.
+    pub fn new_bcj_x86(start_pos: u32) -> Self {
+        Self {
+            filter_type: FilterType::BcjX86,
+            property: start_pos,
+        }
+    }
+
+    /// Creates a new BCJ ARM filter configuration.
+    pub fn new_bcj_arm(start_pos: u32) -> Self {
+        Self {
+            filter_type: FilterType::BcjArm,
+            property: start_pos,
+        }
+    }
+
+    /// Creates a new BCJ ARM Thumb filter configuration.
+    pub fn new_bcj_arm_thumb(start_pos: u32) -> Self {
+        Self {
+            filter_type: FilterType::BcjArmThumb,
+            property: start_pos,
+        }
+    }
+
+    /// Creates a new BCJ ARM64 filter configuration.
+    pub fn new_bcj_arm64(start_pos: u32) -> Self {
+        Self {
+            filter_type: FilterType::BcjArm64,
+            property: start_pos,
+        }
+    }
+
+    /// Creates a new BCJ IA64 filter configuration.
+    pub fn new_bcj_ia64(start_pos: u32) -> Self {
+        Self {
+            filter_type: FilterType::BcjIa64,
+            property: start_pos,
+        }
+    }
+
+    /// Creates a new BCJ PPC filter configuration.
+    pub fn new_bcj_ppc(start_pos: u32) -> Self {
+        Self {
+            filter_type: FilterType::BcjPpc,
+            property: start_pos,
+        }
+    }
+
+    /// Creates a new BCJ SPARC filter configuration.
+    pub fn new_bcj_sparc(start_pos: u32) -> Self {
+        Self {
+            filter_type: FilterType::BcjSparc,
+            property: start_pos,
+        }
+    }
+
+    /// Creates a new BCJ RISC-V filter configuration.
+    pub fn new_bcj_risc_v(start_pos: u32) -> Self {
+        Self {
+            filter_type: FilterType::BcjRiscv,
+            property: start_pos,
+        }
+    }
+}
+
+/// Supported filter types in XZ format.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum FilterType {
+    /// Delta filter
+    Delta,
+    /// BCJ x86 filter
+    BcjX86,
+    /// BCJ PowerPC filter
+    BcjPpc,
+    /// BCJ IA64 filter
+    BcjIa64,
+    /// BCJ ARM filter
+    BcjArm,
+    /// BCJ ARM Thumb
+    BcjArmThumb,
+    /// BCJ SPARC filter
+    BcjSparc,
+    /// BCJ ARM64 filter
+    BcjArm64,
+    /// BCJ RISC-V filter
+    BcjRiscv,
+    /// LZMA2 filter
+    Lzma2,
+}
+
+impl TryFrom<u64> for FilterType {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0x03 => Ok(FilterType::Delta),
+            0x04 => Ok(FilterType::BcjX86),
+            0x05 => Ok(FilterType::BcjPpc),
+            0x06 => Ok(FilterType::BcjIa64),
+            0x07 => Ok(FilterType::BcjArm),
+            0x08 => Ok(FilterType::BcjArmThumb),
+            0x09 => Ok(FilterType::BcjSparc),
+            0x0A => Ok(FilterType::BcjArm64),
+            0x0B => Ok(FilterType::BcjRiscv),
+            0x21 => Ok(FilterType::Lzma2),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,8 +426,8 @@ impl<T: Write> ByteWriter for T {
 
 #[cfg(feature = "std")]
 #[inline(always)]
-fn error_eof() -> Error {
-    Error::new(std::io::ErrorKind::UnexpectedEof, "unexpected EOF")
+fn error_eof(msg: &'static str) -> Error {
+    Error::new(std::io::ErrorKind::UnexpectedEof, msg)
 }
 
 #[cfg(feature = "std")]
@@ -468,7 +468,7 @@ fn copy_error(error: &Error) -> Error {
 
 #[cfg(not(feature = "std"))]
 #[inline(always)]
-fn error_eof() -> Error {
+fn error_eof(_msg: &'static str) -> Error {
     Error::Eof
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ pub(crate) use std::io::Write;
 
 #[cfg(feature = "encoder")]
 pub use enc::*;
+pub use filter::{FilterConfig, FilterType};
 pub use lz::MfType;
 #[cfg(all(feature = "lzip", feature = "std"))]
 pub use lzip::LzipReaderMt;
@@ -121,7 +122,7 @@ pub use xz::XzReaderMt;
 #[cfg(all(feature = "xz", feature = "encoder", feature = "std"))]
 pub use xz::XzWriterMt;
 #[cfg(feature = "xz")]
-pub use xz::{CheckType, FilterConfig, FilterType, XzReader, XzStream};
+pub use xz::{CheckType, XzReader, XzStream};
 #[cfg(all(feature = "xz", feature = "encoder"))]
 pub use xz::{XzOptions, XzWriter};
 

--- a/src/lzip/stream.rs
+++ b/src/lzip/stream.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use super::{HEADER_SIZE, LZIP_MAGIC, LZIP_VERSION, TRAILER_SIZE, decode_dict_size};
 use crate::{
-    Action, LzmaStream, Result, Status, StreamResult, crc::Crc32, error_invalid_data,
+    Action, LzmaStream, Result, Status, StreamResult, crc::Crc32, error_eof, error_invalid_data,
     error_out_of_memory, lzma_reader::get_memory_usage,
 };
 
@@ -277,7 +277,7 @@ impl LzipStream {
                 // long as a member has already been decoded. Anything else is a
                 // truncated stream.
                 if self.state != LzipState::Header || self.members == 0 {
-                    return Err(error_invalid_data("unexpected end of LZIP stream"));
+                    return Err(error_eof("unexpected end of LZIP stream"));
                 }
 
                 self.finish();

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -3,17 +3,21 @@ use alloc::vec::Vec;
 use super::{
     Read,
     decoder::LzmaDecoder,
-    error_eof, error_invalid_data, error_invalid_input, error_out_of_memory,
+    error_eof, error_invalid_data, error_invalid_input, error_out_of_memory, error_unsupported,
     lz::LzDecoder,
     range_dec::{RangeDecoder, RangeDecoderBuffer},
 };
 use crate::{
     ByteReader, DICT_SIZE_MIN,
+    filter::{FilterConfig, StreamFilter},
     lzma_reader::{Limits, LzmaCore, RC_INIT_SIZE},
     stream::{Action, Status, StreamResult},
 };
 
 pub const COMPRESSED_SIZE_MAX: u32 = 1 << 16;
+
+/// How much one drain out of the dictionary moves at most.
+const DRAIN_SIZE_MAX: usize = 4096;
 
 /// A single-threaded LZMA2 decompressor.
 ///
@@ -268,6 +272,13 @@ pub struct Lzma2Stream {
     limits: Limits,
     need_dict_reset: bool,
     need_props: bool,
+    /// The pre-filter the decoded output runs through, if one was set.
+    filter: Option<StreamFilter>,
+    /// Decoded bytes waiting for the filter and the caller. Stays empty, and so
+    /// unallocated, as long as no filter is set.
+    filter_buf: Vec<u8>,
+    /// How much of `filter_buf` the caller has been handed already.
+    filter_pos: usize,
     /// Memory usage limit in KiB. `u32::MAX` means no limit.
     mem_limit_kb: u32,
     /// What the dictionary this stream was built for needs, in KiB.
@@ -300,6 +311,9 @@ impl Lzma2Stream {
             },
             need_dict_reset: true,
             need_props: true,
+            filter: None,
+            filter_buf: Vec::new(),
+            filter_pos: 0,
             mem_limit_kb: u32::MAX,
             mem_need_kb,
             failed: false,
@@ -323,6 +337,29 @@ impl Lzma2Stream {
         }
     }
 
+    /// Decode through a pre-filter, such as a BCJ or delta filter.
+    ///
+    /// At most one filter is supported. [`FilterType::Lzma2`] is not a
+    /// pre-filter and is rejected, as this type is itself the LZMA2 stage. An
+    /// empty slice leaves the stream unfiltered.
+    ///
+    /// Must be called before decoding starts.
+    ///
+    /// [`FilterType::Lzma2`]: crate::FilterType::Lzma2
+    pub fn set_filters(&mut self, filters: &[FilterConfig]) -> crate::Result<()> {
+        if self.total_in != 0 {
+            return Err(error_invalid_input("filters set after decoding started"));
+        }
+        if filters.len() > 1 {
+            return Err(error_unsupported("only one filter is supported"));
+        }
+        let Some(config) = filters.first() else {
+            return Ok(());
+        };
+        self.filter = Some(StreamFilter::new(config)?);
+        Ok(())
+    }
+
     /// Total bytes consumed from input across all `process()` calls.
     pub fn total_in(&self) -> u64 {
         self.total_in
@@ -340,7 +377,7 @@ impl Lzma2Stream {
 
     /// Returns true if there is decoded output waiting to be flushed.
     pub fn has_output(&self) -> bool {
-        self.lz.has_output()
+        self.lz.has_output() || self.filter_pos < self.filter_buf.len()
     }
 
     /// Process available LZMA2 data from `input` into `output`.
@@ -384,8 +421,29 @@ impl Lzma2Stream {
         let mut stalled = false;
 
         loop {
+            // Whatever the state, settled bytes in the staging buffer go out
+            // first. They are already decoded and filtered, so holding them
+            // back would look like a stall to the caller.
+            if self.filter_pos < self.settled_end() && out_pos < output.len() {
+                self.emit_filtered(output, &mut out_pos);
+                continue;
+            }
+
             match self.state {
                 Lzma2State::Finished => {
+                    // Nothing follows the last chunk, so the tail the filter
+                    // held back is settled now and still has to be handed over.
+                    self.finish_filter();
+                    if self.filter_pos < self.settled_end() {
+                        if out_pos >= output.len() {
+                            return Ok(StreamResult {
+                                bytes_consumed: in_pos,
+                                bytes_produced: out_pos,
+                                status: Status::Ok,
+                            });
+                        }
+                        continue;
+                    }
                     return Ok(StreamResult {
                         bytes_consumed: in_pos,
                         bytes_produced: out_pos,
@@ -403,7 +461,9 @@ impl Lzma2Stream {
                             status: Status::Ok,
                         });
                     }
-                    if !self.flush_output(output, &mut out_pos) {
+                    if self.filter.is_some() {
+                        self.drain_and_filter();
+                    } else if !self.flush_output(output, &mut out_pos) {
                         return Ok(StreamResult {
                             bytes_consumed: in_pos,
                             bytes_produced: out_pos,
@@ -464,6 +524,83 @@ impl Lzma2Stream {
         }
         self.finish_drain();
         true
+    }
+
+    /// Where the settled bytes of the staging buffer end.
+    ///
+    /// A BCJ filter can not classify the last bytes of what it was given before
+    /// it knows what follows them, so those stay behind until the next drain or
+    /// the end of the stream.
+    fn settled_end(&self) -> usize {
+        self.filter_buf.len() - self.filter_held_back()
+    }
+
+    fn filter_held_back(&self) -> usize {
+        self.filter.as_ref().map_or(0, |filter| filter.held_back())
+    }
+
+    fn finish_filter(&mut self) {
+        if let Some(filter) = self.filter.as_mut() {
+            filter.finish();
+        }
+    }
+
+    /// Decodes into the staging buffer and runs the filter over what arrived.
+    ///
+    /// The bytes are counted as produced once they reach the caller in
+    /// [`Self::emit_filtered`], not here.
+    fn drain_and_filter(&mut self) {
+        let filter_start = self.settled_end();
+        let drained = Self::flush_to_buf(&mut self.lz, &mut self.filter_buf, DRAIN_SIZE_MAX);
+        if drained > 0 {
+            // The held back tail was never filtered, so it goes through again
+            // together with what now follows it.
+            let unfiltered = &mut self.filter_buf[filter_start..];
+            if let Some(filter) = self.filter.as_mut() {
+                filter.decode(unfiltered);
+            }
+        }
+        if !self.lz.has_output() {
+            self.finish_drain();
+        }
+    }
+
+    /// Hands the settled bytes of the staging buffer to the caller.
+    fn emit_filtered(&mut self, output: &mut [u8], out_pos: &mut usize) {
+        let settled_end = self.settled_end();
+        let n = (settled_end - self.filter_pos).min(output.len() - *out_pos);
+        output[*out_pos..*out_pos + n]
+            .copy_from_slice(&self.filter_buf[self.filter_pos..self.filter_pos + n]);
+        *out_pos += n;
+        self.total_out += n as u64;
+        self.filter_pos += n;
+
+        if self.filter_pos == settled_end {
+            self.compact_filter_buf();
+        }
+    }
+
+    /// Drops what the caller has taken, keeping the held back tail.
+    fn compact_filter_buf(&mut self) {
+        let held_back = self.filter_held_back();
+        let tail_start = self.filter_buf.len() - held_back;
+        if tail_start > 0 {
+            self.filter_buf.copy_within(tail_start.., 0);
+            self.filter_buf.truncate(held_back);
+        }
+        self.filter_pos = 0;
+    }
+
+    /// Moves decoded bytes into `buf`, up to `limit` of them. The caller decides
+    /// whether they count towards `total_out`.
+    fn flush_to_buf(lz: &mut LzDecoder, buf: &mut Vec<u8>, limit: usize) -> usize {
+        let mut tmp = [0u8; DRAIN_SIZE_MAX];
+        let cap = limit.min(tmp.len());
+        let n = lz.flush_partial(&mut tmp[..cap]);
+        if n > 0 {
+            buf.extend_from_slice(&tmp[..n]);
+        }
+        n
     }
 
     /// Decodes what the caller handed us of the current chunk, in place.
@@ -654,13 +791,8 @@ impl Lzma2Stream {
     }
 
     pub(crate) fn drain_to_buf(&mut self, buf: &mut Vec<u8>, limit: usize) -> usize {
-        let mut tmp = [0u8; 4096];
-        let cap = limit.min(tmp.len());
-        let n = self.lz.flush_partial(&mut tmp[..cap]);
-        if n > 0 {
-            buf.extend_from_slice(&tmp[..n]);
-            self.total_out += n as u64;
-        }
+        let n = Self::flush_to_buf(&mut self.lz, buf, limit);
+        self.total_out += n as u64;
         if !self.lz.has_output() {
             self.finish_drain();
         }

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::{
     ByteReader, DICT_SIZE_MIN,
+    lzma_reader::{Limits, LzmaCore, RC_INIT_SIZE},
     stream::{Action, Status, StreamResult},
 };
 
@@ -232,10 +233,11 @@ impl<R: Read> Read for Lzma2Reader<R> {
 #[derive(Clone, Copy)]
 enum Lzma2State {
     ChunkHeader,
-    CompressedData { remaining: usize },
+    RcInit,
+    CompressedData,
     UncompressedData { remaining: usize },
     DrainUncompressed { remaining: usize },
-    Decode,
+    DrainCompressed,
     DrainOutput,
     Finished,
 }
@@ -249,10 +251,11 @@ pub struct Lzma2Stream {
     accum: Vec<u8>,
     accum_needed: usize,
     lz: LzDecoder,
-    rc: RangeDecoder<RangeDecoderBuffer>,
     lzma: Option<LzmaDecoder>,
-    compressed_buf: Vec<u8>,
-    uncompressed_size: usize,
+    /// Decodes straight out of the caller's slice, one chunk at a time.
+    core: LzmaCore,
+    /// The current chunk's uncompressed and compressed budgets.
+    limits: Limits,
     need_dict_reset: bool,
     need_props: bool,
     total_in: u64,
@@ -268,10 +271,16 @@ impl Lzma2Stream {
             accum: Vec::with_capacity(8),
             accum_needed: 1,
             lz: LzDecoder::new(dict_size, None),
-            rc: RangeDecoder::new_buffer(65536),
             lzma: None,
-            compressed_buf: Vec::new(),
-            uncompressed_size: 0,
+            core: LzmaCore::new(),
+            limits: Limits {
+                remaining_size: 0,
+                compressed_left: Some(0),
+                // Every LZMA2 chunk is sized, so an end of payload marker in one
+                // is corruption.
+                allow_end_marker: false,
+                end_reached: false,
+            },
             need_dict_reset: true,
             need_props: true,
             total_in: 0,
@@ -310,6 +319,9 @@ impl Lzma2Stream {
 
         let mut in_pos = 0;
         let mut out_pos = 0;
+        // Set when a decode pass could make no progress at all. Without this
+        // the loop spins forever on an empty input or a full output buffer.
+        let mut stalled = false;
 
         loop {
             match self.state {
@@ -321,7 +333,9 @@ impl Lzma2Stream {
                     });
                 }
 
-                Lzma2State::DrainOutput | Lzma2State::DrainUncompressed { .. } => {
+                Lzma2State::DrainOutput
+                | Lzma2State::DrainCompressed
+                | Lzma2State::DrainUncompressed { .. } => {
                     if out_pos >= output.len() {
                         return Ok(StreamResult {
                             bytes_consumed: in_pos,
@@ -338,17 +352,13 @@ impl Lzma2Stream {
                     }
                 }
 
-                Lzma2State::Decode => {
-                    self.decode_lzma()?;
-                }
-
-                Lzma2State::CompressedData { remaining } => {
+                Lzma2State::CompressedData => {
                     if let Some(result) = self.process_compressed_data(
                         input,
                         action,
                         &mut in_pos,
                         out_pos,
-                        remaining,
+                        &mut stalled,
                     )? {
                         return Ok(result);
                     }
@@ -367,11 +377,17 @@ impl Lzma2Stream {
                 }
 
                 Lzma2State::ChunkHeader => {
-                    if let Some(result) =
-                        self.accumulate_chunk_header(input, action, &mut in_pos, out_pos)?
-                    {
+                    if let Some(result) = self.accumulate(input, action, &mut in_pos, out_pos)? {
                         return Ok(result);
                     }
+                    self.process_chunk_header()?;
+                }
+
+                Lzma2State::RcInit => {
+                    if let Some(result) = self.accumulate(input, action, &mut in_pos, out_pos)? {
+                        return Ok(result);
+                    }
+                    self.init_range_coder()?;
                 }
             }
         }
@@ -390,33 +406,21 @@ impl Lzma2Stream {
         true
     }
 
-    fn decode_lzma(&mut self) -> crate::Result<()> {
-        let pos_before = self.lz.get_pos();
-        self.lz.set_limit(self.uncompressed_size);
-        self.lzma
-            .as_mut()
-            .ok_or_else(|| error_invalid_input("corrupted input data (LZMA2:1)"))?
-            .decode(&mut self.lz, &mut self.rc)?;
-        let decoded = self.lz.get_pos() - pos_before;
-        self.uncompressed_size -= decoded;
-
-        if self.uncompressed_size == 0 && (!self.rc.is_finished() || self.lz.has_pending()) {
-            return Err(error_invalid_input("rc not finished or lz has pending"));
-        }
-
-        self.state = Lzma2State::DrainOutput;
-        Ok(())
-    }
-
+    /// Decodes what the caller handed us of the current chunk, in place.
     fn process_compressed_data(
         &mut self,
         input: &[u8],
         action: Action,
         in_pos: &mut usize,
         out_pos: usize,
-        remaining: usize,
+        stalled: &mut bool,
     ) -> crate::Result<Option<StreamResult>> {
-        if *in_pos >= input.len() {
+        let compressed_left = self.limits.compressed_left.unwrap_or(0);
+
+        // Nothing left to feed and the chunk is not over yet. A chunk whose
+        // compressed size is used up still has to be finished off below, which
+        // takes no input at all.
+        if *in_pos >= input.len() && compressed_left > 0 {
             if action == Action::Finish {
                 return Err(error_invalid_data("unexpected end of LZMA2 stream"));
             }
@@ -426,21 +430,68 @@ impl Lzma2Stream {
                 status: Status::Ok,
             }));
         }
-        let available = &input[*in_pos..];
-        let to_copy = remaining.min(available.len());
-        self.compressed_buf.extend_from_slice(&available[..to_copy]);
-        *in_pos += to_copy;
-        self.total_in += to_copy as u64;
-        let new_remaining = remaining - to_copy;
-        if new_remaining == 0 {
-            self.rc.prepare_from_slice(&self.compressed_buf)?;
-            self.compressed_buf.clear();
-            self.state = Lzma2State::Decode;
-        } else {
-            self.state = Lzma2State::CompressedData {
-                remaining: new_remaining,
-            };
+
+        if *stalled {
+            return Ok(Some(StreamResult {
+                bytes_consumed: *in_pos,
+                bytes_produced: out_pos,
+                status: Status::Ok,
+            }));
         }
+
+        if self.lz.available_space() == 0 {
+            self.state = Lzma2State::DrainCompressed;
+            return Ok(None);
+        }
+
+        let available = &input[*in_pos..];
+        // The chunk header says where the payload ends, so the core can be told
+        // without the caller having to say `Action::Finish`.
+        let input_ends_here = compressed_left <= available.len() as u64;
+
+        let (consumed, produced) = {
+            let Self {
+                lz,
+                lzma,
+                core,
+                limits,
+                ..
+            } = self;
+            let lzma = lzma
+                .as_mut()
+                .ok_or_else(|| error_invalid_input("corrupted input data (LZMA2:1)"))?;
+            core.feed(lz, lzma, available, limits, input_ends_here)?
+        };
+
+        *in_pos += consumed;
+        self.total_in += consumed as u64;
+
+        if consumed == 0 && produced == 0 && !self.limits.end_reached {
+            *stalled = true;
+        }
+
+        if self.limits.end_reached {
+            // The chunk produced everything it declared, so its compressed size
+            // must be used up and the range coder must have ended on zero.
+            //
+            // A used up budget is not enough on its own: the budget counts bytes
+            // taken in, and the last few of those may still be sitting in the
+            // carry unread. The buffered decoder compared the range coder's read
+            // position against the chunk length, so it rejected a chunk that
+            // declared more bytes than any symbol reached. Checking the carry is
+            // empty is how that is said here.
+            if self.limits.compressed_left != Some(0)
+                || !self.core.unused_input().is_empty()
+                || !self.core.rc_finished()
+                || self.lz.has_pending()
+            {
+                return Err(error_invalid_input("rc not finished or lz has pending"));
+            }
+            self.state = Lzma2State::DrainOutput;
+        } else {
+            self.state = Lzma2State::DrainCompressed;
+        }
+
         Ok(None)
     }
 
@@ -473,7 +524,6 @@ impl Lzma2Stream {
             .copy_uncompressed_from_slice(&available[..to_copy])?;
         *in_pos += to_copy;
         self.total_in += to_copy as u64;
-        self.uncompressed_size -= to_copy;
         let new_remaining = remaining - to_copy;
         if new_remaining == 0 {
             self.state = Lzma2State::DrainOutput;
@@ -489,14 +539,16 @@ impl Lzma2Stream {
         Ok(None)
     }
 
-    fn accumulate_chunk_header(
+    /// Fills `accum` up to `accum_needed` bytes, returning a result to hand back
+    /// to the caller when the input ran dry first.
+    fn accumulate(
         &mut self,
         input: &[u8],
         action: Action,
         in_pos: &mut usize,
         out_pos: usize,
     ) -> crate::Result<Option<StreamResult>> {
-        if self.accum.len() < self.accum_needed {
+        while self.accum.len() < self.accum_needed {
             if *in_pos >= input.len() {
                 if action == Action::Finish {
                     return Err(error_invalid_data("unexpected end of LZMA2 stream"));
@@ -507,28 +559,22 @@ impl Lzma2Stream {
                     status: Status::Ok,
                 }));
             }
-            let available = &input[*in_pos..];
             let need = self.accum_needed - self.accum.len();
-            let to_copy = need.min(available.len());
-            self.accum.extend_from_slice(&available[..to_copy]);
+            let to_copy = need.min(input.len() - *in_pos);
+            self.accum
+                .extend_from_slice(&input[*in_pos..*in_pos + to_copy]);
             *in_pos += to_copy;
             self.total_in += to_copy as u64;
-            if self.accum.len() < self.accum_needed {
-                return Ok(Some(StreamResult {
-                    bytes_consumed: *in_pos,
-                    bytes_produced: out_pos,
-                    status: Status::Ok,
-                }));
-            }
         }
-        self.process_chunk_header()?;
         Ok(None)
     }
 
     pub(crate) fn is_draining(&self) -> bool {
         matches!(
             self.state,
-            Lzma2State::DrainOutput | Lzma2State::DrainUncompressed { .. }
+            Lzma2State::DrainOutput
+                | Lzma2State::DrainCompressed
+                | Lzma2State::DrainUncompressed { .. }
         )
     }
 
@@ -566,8 +612,8 @@ impl Lzma2Stream {
             Lzma2State::DrainUncompressed { remaining } => {
                 self.state = Lzma2State::UncompressedData { remaining };
             }
-            _ if self.uncompressed_size > 0 => {
-                self.state = Lzma2State::Decode;
+            Lzma2State::DrainCompressed => {
+                self.state = Lzma2State::CompressedData;
             }
             _ => {
                 self.state = Lzma2State::ChunkHeader;
@@ -606,9 +652,9 @@ impl Lzma2Stream {
             return Err(error_invalid_input("corrupted input data (LZMA2:0)"));
         }
 
-        self.uncompressed_size = ((control & 0x1F) as usize) << 16;
+        let mut uncompressed_size = ((control & 0x1F) as usize) << 16;
         let uncompressed_hi = u16::from_be_bytes([self.accum[1], self.accum[2]]);
-        self.uncompressed_size += uncompressed_hi as usize + 1;
+        uncompressed_size += uncompressed_hi as usize + 1;
         let compressed_size = u16::from_be_bytes([self.accum[3], self.accum[4]]) as usize + 1;
 
         if control >= 0xC0 {
@@ -622,12 +668,32 @@ impl Lzma2Stream {
             }
         }
 
-        self.compressed_buf.clear();
-        self.compressed_buf.reserve(compressed_size);
-        self.state = Lzma2State::CompressedData {
-            remaining: compressed_size,
-        };
+        // The five range coder init bytes count towards the compressed size.
+        if compressed_size < RC_INIT_SIZE {
+            return Err(error_invalid_input("corrupted input data (LZMA2:5)"));
+        }
+
+        // The dictionary and the probability model carry over from the last
+        // chunk, but the range coder starts again.
+        self.core.reset();
+        self.limits.remaining_size = uncompressed_size as u64;
+        self.limits.compressed_left = Some((compressed_size - RC_INIT_SIZE) as u64);
+        self.limits.end_reached = false;
+
+        self.state = Lzma2State::RcInit;
         self.accum.clear();
+        self.accum_needed = RC_INIT_SIZE;
+        Ok(())
+    }
+
+    fn init_range_coder(&mut self) -> crate::Result<()> {
+        let bytes: [u8; RC_INIT_SIZE] = self.accum[..]
+            .try_into()
+            .map_err(|_| error_invalid_input("corrupted input data (LZMA2:3)"))?;
+        self.core.init_rc(&bytes)?;
+        self.accum.clear();
+        self.accum_needed = 0;
+        self.state = Lzma2State::CompressedData;
         Ok(())
     }
 
@@ -645,10 +711,10 @@ impl Lzma2Stream {
             return Err(error_invalid_input("corrupted input data (LZMA2:0)"));
         }
 
-        self.uncompressed_size = u16::from_be_bytes([self.accum[1], self.accum[2]]) as usize + 1;
+        let uncompressed_size = u16::from_be_bytes([self.accum[1], self.accum[2]]) as usize + 1;
 
         self.state = Lzma2State::UncompressedData {
-            remaining: self.uncompressed_size,
+            remaining: uncompressed_size,
         };
         self.accum.clear();
         Ok(())

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -354,6 +354,7 @@ impl Lzma2Stream {
             return Err(error_unsupported("only one filter is supported"));
         }
         let Some(config) = filters.first() else {
+            self.filter = None;
             return Ok(());
         };
         self.filter = Some(StreamFilter::new(config)?);
@@ -377,7 +378,7 @@ impl Lzma2Stream {
 
     /// Returns true if there is decoded output waiting to be flushed.
     pub fn has_output(&self) -> bool {
-        self.lz.has_output() || self.filter_pos < self.filter_buf.len()
+        self.lz.has_output() || self.filter_pos < self.settled_end()
     }
 
     /// Process available LZMA2 data from `input` into `output`.

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -258,6 +258,8 @@ pub struct Lzma2Stream {
     limits: Limits,
     need_dict_reset: bool,
     need_props: bool,
+    /// Set once `process()` has returned an error. A failed stream stays failed.
+    failed: bool,
     total_in: u64,
     total_out: u64,
 }
@@ -283,6 +285,7 @@ impl Lzma2Stream {
             },
             need_dict_reset: true,
             need_props: true,
+            failed: false,
             total_in: 0,
             total_out: 0,
         }
@@ -310,6 +313,23 @@ impl Lzma2Stream {
 
     /// Process available LZMA2 data from `input` into `output`.
     pub fn process(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+    ) -> crate::Result<StreamResult> {
+        if self.failed {
+            return Err(error_invalid_data("LZMA2 stream already failed"));
+        }
+
+        let result = self.process_inner(input, output, action);
+        if result.is_err() {
+            self.failed = true;
+        }
+        result
+    }
+
+    fn process_inner(
         &mut self,
         input: &[u8],
         output: &mut [u8],

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use super::{
     Read,
     decoder::LzmaDecoder,
-    error_invalid_data, error_invalid_input,
+    error_invalid_data, error_invalid_input, error_out_of_memory,
     lz::LzDecoder,
     range_dec::{RangeDecoder, RangeDecoderBuffer},
 };
@@ -47,6 +47,16 @@ pub struct Lzma2Reader<R> {
 #[inline]
 pub fn get_memory_usage(dict_size: u32) -> u32 {
     40 + COMPRESSED_SIZE_MAX / 1024 + get_dict_size(dict_size) / 1024
+}
+
+/// Calculates the memory usage in KiB required by [`Lzma2Stream`].
+///
+/// Unlike [`get_memory_usage`] this leaves out the range decoder buffer, which
+/// the sans-I/O decoder does not have: it decodes straight out of the caller's
+/// input.
+#[inline]
+pub(crate) fn get_stream_memory_usage(dict_size: u32) -> u32 {
+    40 + get_dict_size(dict_size.max(DICT_SIZE_MIN)) / 1024
 }
 
 #[inline]
@@ -258,6 +268,10 @@ pub struct Lzma2Stream {
     limits: Limits,
     need_dict_reset: bool,
     need_props: bool,
+    /// Memory usage limit in KiB. `u32::MAX` means no limit.
+    mem_limit_kb: u32,
+    /// What the dictionary this stream was built for needs, in KiB.
+    mem_need_kb: u32,
     /// Set once `process()` has returned an error. A failed stream stays failed.
     failed: bool,
     total_in: u64,
@@ -267,6 +281,7 @@ pub struct Lzma2Stream {
 impl Lzma2Stream {
     /// Create a new LZMA2 stream decoder with the given dictionary size.
     pub fn new(dict_size: u32) -> Self {
+        let mem_need_kb = get_stream_memory_usage(dict_size);
         let dict_size = get_dict_size(dict_size.max(DICT_SIZE_MIN)) as usize;
         Self {
             state: Lzma2State::ChunkHeader,
@@ -285,9 +300,26 @@ impl Lzma2Stream {
             },
             need_dict_reset: true,
             need_props: true,
+            mem_limit_kb: u32::MAX,
+            mem_need_kb,
             failed: false,
             total_in: 0,
             total_out: 0,
+        }
+    }
+
+    /// Create a new LZMA2 stream decoder with the given dictionary size and a
+    /// memory usage limit.
+    /// - `mem_limit_kb` - memory usage limit in kibibytes (KiB). `u32::MAX` means no limit.
+    ///
+    /// The dictionary is allocated on the first [`process()`] call, so a limit
+    /// violation surfaces from there rather than here.
+    ///
+    /// [`process()`]: Lzma2Stream::process
+    pub fn new_mem_limit(dict_size: u32, mem_limit_kb: u32) -> Self {
+        Self {
+            mem_limit_kb,
+            ..Self::new(dict_size)
         }
     }
 
@@ -335,6 +367,14 @@ impl Lzma2Stream {
         output: &mut [u8],
         action: Action,
     ) -> crate::Result<StreamResult> {
+        // The dictionary is allocated here rather than in the constructor, so
+        // this is where a limit violation surfaces.
+        if self.mem_limit_kb < self.mem_need_kb {
+            return Err(error_out_of_memory(
+                "needed memory too big for mem_limit_kb",
+            ));
+        }
+
         self.lz.ensure_capacity()?;
 
         let mut in_pos = 0;

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use super::{
     Read,
     decoder::LzmaDecoder,
-    error_invalid_data, error_invalid_input, error_out_of_memory,
+    error_eof, error_invalid_data, error_invalid_input, error_out_of_memory,
     lz::LzDecoder,
     range_dec::{RangeDecoder, RangeDecoderBuffer},
 };
@@ -482,7 +482,7 @@ impl Lzma2Stream {
         // takes no input at all.
         if *in_pos >= input.len() && compressed_left > 0 {
             if action == Action::Finish {
-                return Err(error_invalid_data("unexpected end of LZMA2 stream"));
+                return Err(error_eof("unexpected end of LZMA2 stream"));
             }
             return Ok(Some(StreamResult {
                 bytes_consumed: *in_pos,
@@ -570,7 +570,7 @@ impl Lzma2Stream {
         }
         if *in_pos >= input.len() {
             if action == Action::Finish {
-                return Err(error_invalid_data("unexpected end of LZMA2 stream"));
+                return Err(error_eof("unexpected end of LZMA2 stream"));
             }
             return Ok(Some(StreamResult {
                 bytes_consumed: *in_pos,
@@ -611,7 +611,7 @@ impl Lzma2Stream {
         while self.accum.len() < self.accum_needed {
             if *in_pos >= input.len() {
                 if action == Action::Finish {
-                    return Err(error_invalid_data("unexpected end of LZMA2 stream"));
+                    return Err(error_eof("unexpected end of LZMA2 stream"));
                 }
                 return Ok(Some(StreamResult {
                     bytes_consumed: *in_pos,

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     ByteReader, DICT_SIZE_MIN,
     filter::{FilterConfig, StreamFilter},
-    lzma_reader::{Limits, LzmaCore, RC_INIT_SIZE},
+    lzma_reader::{InputEnd, Limits, LzmaCore, RC_INIT_SIZE},
     stream::{Action, Status, StreamResult},
 };
 
@@ -643,8 +643,14 @@ impl Lzma2Stream {
 
         let available = &input[*in_pos..];
         // The chunk header says where the payload ends, so the core can be told
-        // without the caller having to say `Action::Finish`.
-        let input_ends_here = compressed_left <= available.len() as u64;
+        // without the caller having to say `Action::Finish`. A symbol that then
+        // runs past that end is corrupt data in a stream that arrived whole,
+        // not a stream that was cut short.
+        let input_end = if compressed_left <= available.len() as u64 {
+            InputEnd::Length
+        } else {
+            InputEnd::More
+        };
 
         let (consumed, produced) = {
             let Self {
@@ -657,7 +663,7 @@ impl Lzma2Stream {
             let lzma = lzma
                 .as_mut()
                 .ok_or_else(|| error_invalid_input("corrupted input data (LZMA2:1)"))?;
-            core.feed(lz, lzma, available, limits, input_ends_here)?
+            core.feed(lz, lzma, available, limits, input_end)?
         };
 
         *in_pos += consumed;

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use crate::{
     ByteReader, DICT_SIZE_MAX, Read,
     decoder::LzmaDecoder,
-    error_invalid_data, error_invalid_input, error_out_of_memory,
+    error_eof, error_invalid_data, error_invalid_input, error_out_of_memory,
     lz::LzDecoder,
     range_dec::{RangeCoderState, RangeDecoder, SliceRangeReader},
     stream::{Action, Status, StreamResult},
@@ -533,7 +533,7 @@ impl LzmaCore {
         if pos > carry_len {
             // The decoder had to read padding to get here, so the input is
             // really truncated.
-            return Err(error_invalid_data("truncated LZMA stream"));
+            return Err(error_eof("truncated LZMA stream"));
         }
 
         // Padding bytes must never be written back into the carry.
@@ -968,7 +968,7 @@ impl LzmaStream {
         while self.accum.len() < self.accum_needed {
             if *in_pos >= input.len() {
                 if action == Action::Finish {
-                    return Err(error_invalid_data("unexpected end of LZMA stream"));
+                    return Err(error_eof("unexpected end of LZMA stream"));
                 }
                 return Ok(Some(StreamResult {
                     bytes_consumed: *in_pos,

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -3,7 +3,8 @@ use alloc::vec::Vec;
 use crate::{
     ByteReader, DICT_SIZE_MAX, Read,
     decoder::LzmaDecoder,
-    error_eof, error_invalid_data, error_invalid_input, error_out_of_memory,
+    error_eof, error_invalid_data, error_invalid_input, error_out_of_memory, error_unsupported,
+    filter::{FilterConfig, StreamFilter},
     lz::LzDecoder,
     range_dec::{RangeCoderState, RangeDecoder, SliceRangeReader},
     stream::{Action, Status, StreamResult},
@@ -296,6 +297,9 @@ const CARRY_CAP: usize = 2 * IN_REQUIRED;
 /// Bytes the range coder needs to initialise: one zero byte and `code` as four
 /// big endian bytes. An LZMA2 chunk spends these out of its compressed size.
 pub(crate) const RC_INIT_SIZE: usize = 5;
+
+/// How much one drain out of the dictionary moves at most.
+const DRAIN_SIZE_MAX: usize = 4096;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum LzmaState {
@@ -664,6 +668,13 @@ pub struct LzmaStream {
     /// Header and range-coder-init bytes.
     accum: Vec<u8>,
     accum_needed: usize,
+    /// The pre-filter the decoded output runs through, if one was set.
+    filter: Option<StreamFilter>,
+    /// Decoded bytes waiting for the filter and the caller. Stays empty, and so
+    /// unallocated, as long as no filter is set.
+    filter_buf: Vec<u8>,
+    /// How much of `filter_buf` the caller has been handed already.
+    filter_pos: usize,
     mem_limit_kb: u32,
     preset_dict: Option<Vec<u8>>,
     /// Set once `process()` has returned an error. A failed stream stays failed.
@@ -698,6 +709,9 @@ impl LzmaStream {
             },
             accum: Vec::new(),
             accum_needed,
+            filter: None,
+            filter_buf: Vec::new(),
+            filter_pos: 0,
             mem_limit_kb,
             preset_dict: preset_dict.map(|dict| dict.to_vec()),
             failed: false,
@@ -787,6 +801,29 @@ impl LzmaStream {
         ))
     }
 
+    /// Decode through a pre-filter, such as a BCJ or delta filter.
+    ///
+    /// At most one filter is supported. [`FilterType::Lzma2`] is not a
+    /// pre-filter and is rejected, as this type is the LZMA1 stage. An empty
+    /// slice leaves the stream unfiltered.
+    ///
+    /// Must be called before decoding starts.
+    ///
+    /// [`FilterType::Lzma2`]: crate::FilterType::Lzma2
+    pub fn set_filters(&mut self, filters: &[FilterConfig]) -> crate::Result<()> {
+        if self.total_in != 0 {
+            return Err(error_invalid_input("filters set after decoding started"));
+        }
+        if filters.len() > 1 {
+            return Err(error_unsupported("only one filter is supported"));
+        }
+        let Some(config) = filters.first() else {
+            return Ok(());
+        };
+        self.filter = Some(StreamFilter::new(config)?);
+        Ok(())
+    }
+
     /// Total bytes consumed from input across all `process()` calls.
     pub fn total_in(&self) -> u64 {
         self.total_in
@@ -805,6 +842,7 @@ impl LzmaStream {
     /// Returns true if there is decoded output waiting to be flushed.
     pub fn has_output(&self) -> bool {
         self.lz.as_ref().is_some_and(|lz| lz.has_output())
+            || self.filter_pos < self.filter_buf.len()
     }
 
     /// Bytes that were absorbed from the caller but turned out not to belong to
@@ -859,8 +897,30 @@ impl LzmaStream {
         let mut stalled = false;
 
         loop {
+            // Whatever the state, settled bytes in the staging buffer go out
+            // first. They are already decoded and filtered, so holding them
+            // back would look like a stall to the caller.
+            if self.filter_pos < self.settled_end() && out_pos < output.len() {
+                self.emit_filtered(output, &mut out_pos);
+                continue;
+            }
+
             match self.state {
                 LzmaState::Finished => {
+                    // Nothing follows the last decoded byte, so the tail the
+                    // filter held back is settled now and still has to be
+                    // handed over.
+                    self.finish_filter();
+                    if self.filter_pos < self.settled_end() {
+                        if out_pos >= output.len() {
+                            return Ok(StreamResult {
+                                bytes_consumed: in_pos,
+                                bytes_produced: out_pos,
+                                status: Status::Ok,
+                            });
+                        }
+                        continue;
+                    }
                     return Ok(StreamResult {
                         bytes_consumed: in_pos,
                         bytes_produced: out_pos,
@@ -924,30 +984,138 @@ impl LzmaStream {
                         });
                     }
 
-                    let (flushed, has_output) = {
-                        let lz = self.lz_mut()?;
-                        let flushed = lz.flush_partial(&mut output[out_pos..]);
-                        (flushed, lz.has_output())
-                    };
-                    out_pos += flushed;
-                    self.total_out += flushed as u64;
-
-                    if has_output {
+                    if self.filter.is_some() {
+                        self.drain_and_filter()?;
+                    } else if !self.flush_output(output, &mut out_pos)? {
                         return Ok(StreamResult {
                             bytes_consumed: in_pos,
                             bytes_produced: out_pos,
                             status: Status::Ok,
                         });
                     }
-
-                    self.state = if self.limits.end_reached {
-                        LzmaState::Finished
-                    } else {
-                        LzmaState::Decode
-                    };
                 }
             }
         }
+    }
+
+    /// Hands decoded bytes straight to the caller, returning false when the
+    /// output buffer filled before the dictionary ran dry.
+    fn flush_output(&mut self, output: &mut [u8], out_pos: &mut usize) -> crate::Result<bool> {
+        let (flushed, has_output) = {
+            let lz = self.lz_mut()?;
+            let flushed = lz.flush_partial(&mut output[*out_pos..]);
+            (flushed, lz.has_output())
+        };
+        *out_pos += flushed;
+        self.total_out += flushed as u64;
+
+        if has_output {
+            return Ok(false);
+        }
+        self.finish_drain();
+        Ok(true)
+    }
+
+    /// Where the settled bytes of the staging buffer end.
+    ///
+    /// A BCJ filter can not classify the last bytes of what it was given before
+    /// it knows what follows them, so those stay behind until the next drain or
+    /// the end of the stream.
+    fn settled_end(&self) -> usize {
+        self.filter_buf.len() - self.filter_held_back()
+    }
+
+    fn filter_held_back(&self) -> usize {
+        self.filter.as_ref().map_or(0, |filter| filter.held_back())
+    }
+
+    fn finish_filter(&mut self) {
+        if let Some(filter) = self.filter.as_mut() {
+            filter.finish();
+        }
+    }
+
+    /// Decodes into the staging buffer and runs the filter over what arrived.
+    ///
+    /// The bytes are counted as produced once they reach the caller in
+    /// [`Self::emit_filtered`], not here.
+    fn drain_and_filter(&mut self) -> crate::Result<()> {
+        let filter_start = self.settled_end();
+
+        let has_output = {
+            let Self {
+                lz,
+                filter,
+                filter_buf,
+                ..
+            } = self;
+            let lz = lz
+                .as_mut()
+                .ok_or_else(|| error_invalid_data("LZMA decoder not initialized"))?;
+
+            let drained = Self::flush_to_buf(lz, filter_buf, DRAIN_SIZE_MAX);
+            if drained > 0 {
+                // The held back tail was never filtered, so it goes through
+                // again together with what now follows it.
+                let unfiltered = &mut filter_buf[filter_start..];
+                if let Some(filter) = filter.as_mut() {
+                    filter.decode(unfiltered);
+                }
+            }
+            lz.has_output()
+        };
+
+        if !has_output {
+            self.finish_drain();
+        }
+        Ok(())
+    }
+
+    /// Hands the settled bytes of the staging buffer to the caller.
+    fn emit_filtered(&mut self, output: &mut [u8], out_pos: &mut usize) {
+        let settled_end = self.settled_end();
+        let n = (settled_end - self.filter_pos).min(output.len() - *out_pos);
+        output[*out_pos..*out_pos + n]
+            .copy_from_slice(&self.filter_buf[self.filter_pos..self.filter_pos + n]);
+        *out_pos += n;
+        self.total_out += n as u64;
+        self.filter_pos += n;
+
+        if self.filter_pos == settled_end {
+            self.compact_filter_buf();
+        }
+    }
+
+    /// Drops what the caller has taken, keeping the held back tail.
+    fn compact_filter_buf(&mut self) {
+        let held_back = self.filter_held_back();
+        let tail_start = self.filter_buf.len() - held_back;
+        if tail_start > 0 {
+            self.filter_buf.copy_within(tail_start.., 0);
+            self.filter_buf.truncate(held_back);
+        }
+        self.filter_pos = 0;
+    }
+
+    /// Moves decoded bytes into `buf`, up to `limit` of them. The caller decides
+    /// whether they count towards `total_out`.
+    fn flush_to_buf(lz: &mut LzDecoder, buf: &mut Vec<u8>, limit: usize) -> usize {
+        let mut tmp = [0u8; DRAIN_SIZE_MAX];
+        let cap = limit.min(tmp.len());
+        let n = lz.flush_partial(&mut tmp[..cap]);
+        if n > 0 {
+            buf.extend_from_slice(&tmp[..n]);
+        }
+        n
+    }
+
+    /// Where a finished drain leaves the stream: over, or back to decoding.
+    fn finish_drain(&mut self) {
+        self.state = if self.limits.end_reached {
+            LzmaState::Finished
+        } else {
+            LzmaState::Decode
+        };
     }
 
     fn lz_mut(&mut self) -> crate::Result<&mut LzDecoder> {

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -387,13 +387,18 @@ impl LzmaCore {
 
     /// Runs one decode pass over `input`, returning `(bytes consumed from
     /// input, bytes decoded into the dictionary)`.
+    ///
+    /// `input_ends_here` says that nothing follows this slice, so the last
+    /// bytes of it may be decoded against zero padding. LZMA1 knows that from
+    /// the action the caller gave it; an LZMA2 chunk knows it from the
+    /// compressed size in its own header.
     pub(crate) fn feed(
         &mut self,
         lz: &mut LzDecoder,
         lzma: &mut LzmaDecoder,
         input: &[u8],
         limits: &mut Limits,
-        action: Action,
+        input_ends_here: bool,
     ) -> crate::Result<(usize, usize)> {
         // Clamp before anything decides where a symbol may start, so no symbol
         // can reach a byte the budget does not cover. An LZMA2 chunk is
@@ -409,7 +414,7 @@ impl LzmaCore {
 
         // No more input will ever arrive, so go straight to the finish tail
         // rather than pointlessly re-running the carry.
-        let finish_now = action == Action::Finish && input.is_empty();
+        let finish_now = input_ends_here && input.is_empty();
 
         // Set when the carry could not be drained. The caller's remaining input
         // cannot be decoded in place until it has been.
@@ -481,7 +486,7 @@ impl LzmaCore {
 
         // Decode the carry against zero padding and require the stream to end
         // inside the real bytes.
-        if action == Action::Finish && !limits.end_reached && in_pos >= input.len() {
+        if input_ends_here && !limits.end_reached && in_pos >= input.len() {
             produced += self.decode_finish_tail(lz, lzma, limits)?;
         }
 
@@ -1063,7 +1068,12 @@ impl LzmaStream {
             _ => return Err(error_invalid_data("LZMA decoder not initialized")),
         };
 
-        let (consumed, produced) = core.feed(lz, lzma, &input[*in_pos..], limits, action)?;
+        // For LZMA1 the caller is the only one who knows whether more input is
+        // coming, and `Action::Finish` is how it says so.
+        let input_ends_here = action == Action::Finish;
+
+        let (consumed, produced) =
+            core.feed(lz, lzma, &input[*in_pos..], limits, input_ends_here)?;
         *in_pos += consumed;
         self.total_in += consumed as u64;
 
@@ -1138,7 +1148,7 @@ mod tests {
         // Four bytes of a nineteen byte payload on offer: only four may be
         // taken, and they are too few to start a symbol from.
         let (consumed, produced) = core
-            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, Action::Run)
+            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, false)
             .unwrap();
         assert_eq!(consumed, 4);
         assert_eq!(produced, 0);
@@ -1146,7 +1156,7 @@ mod tests {
 
         // A used up budget stops the core dead, however much input is left.
         let (consumed, produced) = core
-            .feed(&mut lz, &mut lzma, &RAW[9..], &mut limits, Action::Run)
+            .feed(&mut lz, &mut lzma, &RAW[9..], &mut limits, false)
             .unwrap();
         assert_eq!(consumed, 0);
         assert_eq!(produced, 0);
@@ -1158,7 +1168,7 @@ mod tests {
         let mut limits = limits(None);
 
         let (consumed, produced) = core
-            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, Action::Finish)
+            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, true)
             .unwrap();
         assert_eq!(consumed, RAW.len() - 5);
         assert_eq!(produced, 13);

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -319,6 +319,10 @@ fn room_for(lz: &LzDecoder, remaining_size: u64) -> usize {
 pub(crate) struct Limits {
     /// Uncompressed bytes still to produce. `u64::MAX` means unknown.
     pub(crate) remaining_size: u64,
+    /// Compressed bytes still allowed. `None` means unbounded, which is what
+    /// LZMA1 wants: it is the declared uncompressed size or the end of payload
+    /// marker that ends such a stream, not a byte count.
+    pub(crate) compressed_left: Option<u64>,
     /// Whether the stream may end with an end of payload marker rather than by
     /// running out of declared size.
     pub(crate) allow_end_marker: bool,
@@ -391,6 +395,15 @@ impl LzmaCore {
         limits: &mut Limits,
         action: Action,
     ) -> crate::Result<(usize, usize)> {
+        // Clamp before anything decides where a symbol may start, so no symbol
+        // can reach a byte the budget does not cover. An LZMA2 chunk is
+        // followed by the next chunk's header, and `SliceRangeReader` cannot
+        // un-consume read-ahead the way a buffered reader can.
+        let input = match limits.compressed_left {
+            Some(left) => &input[..input.len().min(left.min(usize::MAX as u64) as usize)],
+            None => input,
+        };
+
         let mut in_pos = 0;
         let mut produced = 0;
 
@@ -458,6 +471,12 @@ impl LzmaCore {
                 self.carry_len = rest;
                 in_pos = input.len();
             }
+        }
+
+        // Bytes taken into the carry count against the budget too: they were
+        // read out of the caller's slice and belong to this decode unit.
+        if let Some(left) = limits.compressed_left.as_mut() {
+            *left -= in_pos as u64;
         }
 
         // Decode the carry against zero padding and require the stream to end
@@ -661,6 +680,8 @@ impl LzmaStream {
             core: LzmaCore::new(),
             limits: Limits {
                 remaining_size,
+                // LZMA1 has no compressed size to go by.
+                compressed_left: None,
                 // A stream of unknown size is the only one that may end with an
                 // end of payload marker.
                 allow_end_marker: remaining_size == u64::MAX,
@@ -1077,4 +1098,74 @@ fn build_decoders(
     let lz = LzDecoder::new(get_dict_size(dict_size)? as _, preset_dict);
     let lzma = LzmaDecoder::new(lc, lp, pb);
     Ok((lz, lzma))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// "Hello, world!" as a raw LZMA stream: five range coder init bytes and
+    /// then nineteen bytes of payload, ended by an end of payload marker. The
+    /// properties are `lc = 3`, `lp = 0`, `pb = 2`.
+    const RAW: [u8; 24] = [
+        0, 36, 25, 73, 152, 111, 22, 2, 140, 232, 230, 91, 177, 71, 198, 206, 183, 99, 255, 255,
+        60, 172, 0, 0,
+    ];
+
+    fn parts() -> (LzDecoder, LzmaDecoder, LzmaCore) {
+        let (mut lz, lzma) = build_decoders(u64::MAX, 3, 0, 2, 0x0080_0000, None).unwrap();
+        lz.ensure_capacity().unwrap();
+        let mut core = LzmaCore::new();
+        core.init_rc(&[RAW[0], RAW[1], RAW[2], RAW[3], RAW[4]])
+            .unwrap();
+        (lz, lzma, core)
+    }
+
+    fn limits(compressed_left: Option<u64>) -> Limits {
+        Limits {
+            remaining_size: u64::MAX,
+            compressed_left,
+            allow_end_marker: true,
+            end_reached: false,
+        }
+    }
+
+    #[test]
+    fn compressed_budget_stops_the_core() {
+        let (mut lz, mut lzma, mut core) = parts();
+        let mut limits = limits(Some(4));
+
+        // Four bytes of a nineteen byte payload on offer: only four may be
+        // taken, and they are too few to start a symbol from.
+        let (consumed, produced) = core
+            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, Action::Run)
+            .unwrap();
+        assert_eq!(consumed, 4);
+        assert_eq!(produced, 0);
+        assert_eq!(limits.compressed_left, Some(0));
+
+        // A used up budget stops the core dead, however much input is left.
+        let (consumed, produced) = core
+            .feed(&mut lz, &mut lzma, &RAW[9..], &mut limits, Action::Run)
+            .unwrap();
+        assert_eq!(consumed, 0);
+        assert_eq!(produced, 0);
+    }
+
+    #[test]
+    fn no_budget_decodes_the_whole_payload() {
+        let (mut lz, mut lzma, mut core) = parts();
+        let mut limits = limits(None);
+
+        let (consumed, produced) = core
+            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, Action::Finish)
+            .unwrap();
+        assert_eq!(consumed, RAW.len() - 5);
+        assert_eq!(produced, 13);
+        assert!(limits.end_reached);
+
+        let mut out = [0u8; 13];
+        assert_eq!(lz.flush_partial(&mut out), 13);
+        assert_eq!(&out, b"Hello, world!");
+    }
 }

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -303,15 +303,291 @@ enum LzmaState {
 }
 
 /// Output space the decoder may fill before it has to stop.
-fn room_for(lz: Option<&LzDecoder>, remaining_size: u64) -> usize {
-    let Some(lz) = lz else {
-        return 0;
-    };
+fn room_for(lz: &LzDecoder, remaining_size: u64) -> usize {
     let mut room = lz.available_space();
     if remaining_size <= u64::MAX / 2 {
         room = room.min(remaining_size.min(usize::MAX as u64) as usize);
     }
     room
+}
+
+/// What a decode pass is allowed to do, and what it has already done.
+///
+/// This is the caller's, not the core's: an LZMA2 chunk restarts the range
+/// coder but goes on counting against the dictionary it shares with every other
+/// chunk.
+pub(crate) struct Limits {
+    /// Uncompressed bytes still to produce. `u64::MAX` means unknown.
+    pub(crate) remaining_size: u64,
+    /// Whether the stream may end with an end of payload marker rather than by
+    /// running out of declared size.
+    pub(crate) allow_end_marker: bool,
+    /// Set once the end of the stream has been seen.
+    pub(crate) end_reached: bool,
+}
+
+/// The part of an LZMA1 decode that has to survive between `process()` calls,
+/// minus the dictionary and the probability model it works on.
+///
+/// Decoding straight out of the caller's slice means stopping before a symbol
+/// could run off the end of it, so whatever is left over has to be carried into
+/// the next call and stitched to the bytes that arrive then. That, plus the
+/// range coder state, is all this holds; the decoders are passed in, because
+/// LZMA2 needs the same machinery over a dictionary that outlives any single
+/// chunk.
+pub(crate) struct LzmaCore {
+    rc: RangeCoderState,
+    /// Bytes taken from the caller that were too few to start a symbol from.
+    carry: [u8; CARRY_CAP],
+    carry_len: usize,
+}
+
+impl LzmaCore {
+    pub(crate) fn new() -> Self {
+        Self {
+            rc: RangeCoderState::default(),
+            carry: [0; CARRY_CAP],
+            carry_len: 0,
+        }
+    }
+
+    /// Forgets the current range coder run. An LZMA2 chunk starts a new one over
+    /// the dictionary the previous chunk left behind.
+    pub(crate) fn reset(&mut self) {
+        self.rc = RangeCoderState::default();
+        self.carry_len = 0;
+    }
+
+    /// Incremental equivalent of [`RangeDecoder::new_stream`]: the first byte
+    /// must be zero, the next four are `code` in big endian order.
+    pub(crate) fn init_rc(&mut self, bytes: &[u8; 5]) -> crate::Result<()> {
+        if bytes[0] != 0x00 {
+            return Err(error_invalid_input("range decoder first byte is not zero"));
+        }
+        self.rc = RangeCoderState {
+            range: 0xFFFF_FFFF,
+            code: u32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]),
+        };
+        Ok(())
+    }
+
+    /// True when the range coder ended on zero, as a well formed stream does.
+    pub(crate) fn rc_finished(&self) -> bool {
+        self.rc.code == 0
+    }
+
+    /// Bytes that were taken in but never decoded. Never more than 40.
+    pub(crate) fn unused_input(&self) -> &[u8] {
+        &self.carry[..self.carry_len]
+    }
+
+    /// Runs one decode pass over `input`, returning `(bytes consumed from
+    /// input, bytes decoded into the dictionary)`.
+    pub(crate) fn feed(
+        &mut self,
+        lz: &mut LzDecoder,
+        lzma: &mut LzmaDecoder,
+        input: &[u8],
+        limits: &mut Limits,
+        action: Action,
+    ) -> crate::Result<(usize, usize)> {
+        let mut in_pos = 0;
+        let mut produced = 0;
+
+        // No more input will ever arrive, so go straight to the finish tail
+        // rather than pointlessly re-running the carry.
+        let finish_now = action == Action::Finish && input.is_empty();
+
+        // Set when the carry could not be drained. The caller's remaining input
+        // cannot be decoded in place until it has been.
+        let mut carry_blocked = false;
+
+        // Decode across the boundary between the bytes carried over from an
+        // earlier call and the fresh input.
+        if self.carry_len > 0 && !finish_now {
+            let carry_len = self.carry_len;
+            let m = (input.len() - in_pos).min(CARRY_CAP - carry_len);
+            let filled = carry_len + m;
+
+            let mut scratch = self.carry;
+            scratch[carry_len..filled].copy_from_slice(&input[in_pos..in_pos + m]);
+
+            let symbol_limit = filled.saturating_sub(IN_REQUIRED - 1);
+            let (pos, decoded) =
+                self.run(lz, lzma, limits, &scratch[..filled], filled, symbol_limit)?;
+            produced += decoded;
+
+            if pos >= carry_len {
+                // The carry is drained. Un-consume the scratch residue so the
+                // direct path below can pick it up in place.
+                in_pos += pos - carry_len;
+                self.carry_len = 0;
+            } else {
+                // Only reachable when `m < IN_REQUIRED`, i.e. the caller did
+                // not hand us enough to complete even one symbol. The residue
+                // can be as large as `CARRY_CAP - 1`.
+                let residue = filled - pos;
+                self.carry[..residue].copy_from_slice(&scratch[pos..filled]);
+                self.carry_len = residue;
+                in_pos += m;
+                carry_blocked = true;
+            }
+        }
+
+        // Decode in place over the caller's buffer, zero copy.
+        if !carry_blocked && !limits.end_reached {
+            let avail = input.len() - in_pos;
+            if avail >= IN_REQUIRED {
+                // A symbol may start only while `pos + IN_REQUIRED <= avail`,
+                // that is while `pos < avail - (IN_REQUIRED - 1)`.
+                let symbol_limit = avail - (IN_REQUIRED - 1);
+                let (pos, decoded) =
+                    self.run(lz, lzma, limits, &input[in_pos..], avail, symbol_limit)?;
+                produced += decoded;
+                in_pos += pos;
+            }
+        }
+
+        // What is left is too short to start a symbol from, so take it into the
+        // carry.
+        if !carry_blocked && !limits.end_reached {
+            let rest = input.len() - in_pos;
+            if rest > 0 && rest < IN_REQUIRED {
+                debug_assert_eq!(self.carry_len, 0);
+                self.carry[..rest].copy_from_slice(&input[in_pos..]);
+                self.carry_len = rest;
+                in_pos = input.len();
+            }
+        }
+
+        // Decode the carry against zero padding and require the stream to end
+        // inside the real bytes.
+        if action == Action::Finish && !limits.end_reached && in_pos >= input.len() {
+            produced += self.decode_finish_tail(lz, lzma, limits)?;
+        }
+
+        Ok((in_pos, produced))
+    }
+
+    /// Decodes what is left of the carry with padding zeros behind it, so the
+    /// decoder still sees the 20 bytes it needs to start one more symbol.
+    ///
+    /// The carry bytes were counted as consumed when they were taken in, so this
+    /// adds nothing to `bytes_consumed`.
+    fn decode_finish_tail(
+        &mut self,
+        lz: &mut LzDecoder,
+        lzma: &mut LzmaDecoder,
+        limits: &mut Limits,
+    ) -> crate::Result<usize> {
+        if room_for(lz, limits.remaining_size) == 0 {
+            // No output space, so we cannot yet tell whether the stream really
+            // ends here. The caller has to drain first.
+            return Ok(0);
+        }
+
+        let carry_len = self.carry_len;
+
+        // One symbol may start at `pos == carry_len` and read up to
+        // `IN_REQUIRED` bytes from there, so at least that many zeros follow.
+        let mut scratch = [0u8; CARRY_CAP + IN_REQUIRED + 1];
+        scratch[..carry_len].copy_from_slice(&self.carry[..carry_len]);
+        let padded_len = carry_len + IN_REQUIRED + 1;
+        let (pos, produced) = self.run(
+            lz,
+            lzma,
+            limits,
+            &scratch[..padded_len],
+            carry_len,
+            carry_len + 1,
+        )?;
+
+        if pos > carry_len {
+            // The decoder had to read padding to get here, so the input is
+            // really truncated.
+            return Err(error_invalid_data("truncated LZMA stream"));
+        }
+
+        // Padding bytes must never be written back into the carry.
+        self.carry.copy_within(pos..carry_len, 0);
+        self.carry_len = carry_len - pos;
+
+        Ok(produced)
+    }
+
+    /// Decodes as much as fits from `buf`, returning `(read position, bytes
+    /// decoded into the dictionary)`.
+    fn run(
+        &mut self,
+        lz: &mut LzDecoder,
+        lzma: &mut LzmaDecoder,
+        limits: &mut Limits,
+        buf: &[u8],
+        real_len: usize,
+        symbol_limit: usize,
+    ) -> crate::Result<(usize, usize)> {
+        let room = room_for(lz, limits.remaining_size);
+        if room == 0 {
+            return Ok((0, 0));
+        }
+
+        let pos_before = lz.get_pos();
+        lz.set_limit(room);
+
+        let mut rc =
+            RangeDecoder::from_parts(SliceRangeReader::new(buf, real_len, symbol_limit), self.rc);
+        let decode_result = lzma.decode(lz, &mut rc);
+
+        // Must be read before anything can flush: `flush_partial` wraps `pos`
+        // back to zero once the dictionary is full and fully drained.
+        let produced = lz.get_pos() - pos_before;
+
+        let mut error = None;
+        if let Err(decode_error) = decode_result {
+            // An end of payload marker surfaces as an error, because the decoder
+            // calls `lz.repeat(0xFFFF_FFFF, len)`, which fails with "dist
+            // overflow". Anything else is genuine corruption. Check the order:
+            // `end_marker_detected()` is only meaningful right after a failed
+            // `repeat`.
+            if !limits.allow_end_marker || !lzma.end_marker_detected() {
+                error = Some(decode_error);
+            } else {
+                if rc.can_normalize() {
+                    rc.normalize();
+                }
+                // Only once the stream is known to end cleanly, or a caller that
+                // calls again after the error is told it did.
+                if rc.is_stream_finished() {
+                    limits.end_reached = true;
+                } else {
+                    error = Some(error_invalid_data("LZMA stream not properly terminated"));
+                }
+            }
+        }
+
+        // The reported position is only ever compared against buffer bounds:
+        // the assembly `decode_direct_bits` advances `pos` past what a symbol
+        // logically needed and clamps its reads instead of signalling.
+        let pos = rc.inner().pos().min(buf.len());
+        self.rc = rc.state();
+
+        if let Some(error) = error {
+            return Err(error);
+        }
+
+        if limits.remaining_size <= u64::MAX / 2 {
+            limits.remaining_size -= produced as u64;
+            if limits.remaining_size == 0 {
+                limits.end_reached = true;
+            }
+        }
+
+        if limits.end_reached && lz.has_pending() {
+            return Err(error_invalid_data("end reached but not decoder finished"));
+        }
+
+        Ok((pos, produced))
+    }
 }
 
 /// A sans-I/O LZMA1 stream decoder.
@@ -355,19 +631,13 @@ pub struct LzmaStream {
     lz: Option<LzDecoder>,
     /// `None` until the properties byte is known (header mode).
     lzma: Option<LzmaDecoder>,
-    rc: RangeCoderState,
-    /// Bytes taken from the caller that were too few to start a symbol from.
-    carry: [u8; CARRY_CAP],
-    carry_len: usize,
+    core: LzmaCore,
+    limits: Limits,
     /// Header and range-coder-init bytes.
     accum: Vec<u8>,
     accum_needed: usize,
-    /// `u64::MAX` means unknown; such a stream is terminated by an end of
-    /// payload marker.
-    remaining_size: u64,
     mem_limit_kb: u32,
     preset_dict: Option<Vec<u8>>,
-    end_reached: bool,
     /// Set once `process()` has returned an error. A failed stream stays failed.
     failed: bool,
     total_in: u64,
@@ -388,15 +658,18 @@ impl LzmaStream {
             state,
             lz,
             lzma,
-            rc: RangeCoderState::default(),
-            carry: [0; CARRY_CAP],
-            carry_len: 0,
+            core: LzmaCore::new(),
+            limits: Limits {
+                remaining_size,
+                // A stream of unknown size is the only one that may end with an
+                // end of payload marker.
+                allow_end_marker: remaining_size == u64::MAX,
+                end_reached: false,
+            },
             accum: Vec::new(),
             accum_needed,
-            remaining_size,
             mem_limit_kb,
             preset_dict: preset_dict.map(|dict| dict.to_vec()),
-            end_reached: false,
             failed: false,
             total_in: 0,
             total_out: 0,
@@ -519,7 +792,7 @@ impl LzmaStream {
     /// as [`LzmaReader`] does.
     pub fn unused_input(&self) -> &[u8] {
         if self.state == LzmaState::Finished {
-            &self.carry[..self.carry_len]
+            self.core.unused_input()
         } else {
             &[]
         }
@@ -590,8 +863,8 @@ impl LzmaStream {
 
                     // A stream whose declared size is zero is already over; no
                     // decode pass will ever set this for us.
-                    if self.remaining_size == 0 {
-                        self.end_reached = true;
+                    if self.limits.remaining_size == 0 {
+                        self.limits.end_reached = true;
                     }
 
                     let space = {
@@ -600,13 +873,13 @@ impl LzmaStream {
                         lz.available_space()
                     };
 
-                    if self.end_reached || space == 0 {
+                    if self.limits.end_reached || space == 0 {
                         self.state = LzmaState::DrainOutput;
                         continue;
                     }
 
                     let (consumed, produced) = self.decode_pass(input, &mut in_pos, action)?;
-                    if consumed == 0 && produced == 0 && !self.end_reached {
+                    if consumed == 0 && produced == 0 && !self.limits.end_reached {
                         stalled = true;
                     }
                     self.state = LzmaState::DrainOutput;
@@ -637,7 +910,7 @@ impl LzmaStream {
                         });
                     }
 
-                    self.state = if self.end_reached {
+                    self.state = if self.limits.end_reached {
                         LzmaState::Finished
                     } else {
                         LzmaState::Decode
@@ -728,7 +1001,8 @@ impl LzmaStream {
         )?;
         self.lz = Some(lz);
         self.lzma = Some(lzma);
-        self.remaining_size = uncomp_size;
+        self.limits.remaining_size = uncomp_size;
+        self.limits.allow_end_marker = uncomp_size == u64::MAX;
 
         self.accum.clear();
         self.accum_needed = 5;
@@ -736,16 +1010,11 @@ impl LzmaStream {
         Ok(())
     }
 
-    /// Incremental equivalent of [`RangeDecoder::new_stream`]: the first byte
-    /// must be zero, the next four are `code` in big endian order.
     fn init_range_coder(&mut self) -> crate::Result<()> {
-        if self.accum[0] != 0x00 {
-            return Err(error_invalid_input("range decoder first byte is not zero"));
-        }
-        self.rc = RangeCoderState {
-            range: 0xFFFF_FFFF,
-            code: u32::from_be_bytes([self.accum[1], self.accum[2], self.accum[3], self.accum[4]]),
-        };
+        let bytes: [u8; 5] = self.accum[..]
+            .try_into()
+            .map_err(|_| error_invalid_input("range coder init needs five bytes"))?;
+        self.core.init_rc(&bytes)?;
         self.accum.clear();
         self.accum_needed = 0;
         self.state = LzmaState::Decode;
@@ -760,213 +1029,24 @@ impl LzmaStream {
         in_pos: &mut usize,
         action: Action,
     ) -> crate::Result<(usize, usize)> {
-        let mut consumed = 0;
-        let mut produced = 0;
-
-        // No more input will ever arrive, so go straight to the finish tail
-        // rather than pointlessly re-running the carry.
-        let finish_now = action == Action::Finish && *in_pos >= input.len();
-
-        // Set when the carry could not be drained. The caller's remaining input
-        // cannot be decoded in place until it has been.
-        let mut carry_blocked = false;
-
-        // Decode across the boundary between the bytes carried over from an
-        // earlier call and the fresh input.
-        if self.carry_len > 0 && !finish_now {
-            let carry_len = self.carry_len;
-            let m = (input.len() - *in_pos).min(CARRY_CAP - carry_len);
-            let filled = carry_len + m;
-
-            let mut scratch = self.carry;
-            scratch[carry_len..filled].copy_from_slice(&input[*in_pos..*in_pos + m]);
-
-            let symbol_limit = filled.saturating_sub(IN_REQUIRED - 1);
-            let (pos, decoded) = self.run(&scratch[..filled], filled, symbol_limit)?;
-            produced += decoded;
-
-            if pos >= carry_len {
-                // The carry is drained. Un-consume the scratch residue so the
-                // direct path below can pick it up in place.
-                let extra = pos - carry_len;
-                *in_pos += extra;
-                self.total_in += extra as u64;
-                consumed += extra;
-                self.carry_len = 0;
-            } else {
-                // Only reachable when `m < IN_REQUIRED`, i.e. the caller did
-                // not hand us enough to complete even one symbol. The residue
-                // can be as large as `CARRY_CAP - 1`.
-                let residue = filled - pos;
-                self.carry[..residue].copy_from_slice(&scratch[pos..filled]);
-                self.carry_len = residue;
-                *in_pos += m;
-                self.total_in += m as u64;
-                consumed += m;
-                carry_blocked = true;
-            }
-        }
-
-        // Decode in place over the caller's buffer, zero copy.
-        if !carry_blocked && !self.end_reached {
-            let avail = input.len() - *in_pos;
-            if avail >= IN_REQUIRED {
-                // A symbol may start only while `pos + IN_REQUIRED <= avail`,
-                // that is while `pos < avail - (IN_REQUIRED - 1)`.
-                let symbol_limit = avail - (IN_REQUIRED - 1);
-                let (pos, decoded) = self.run(&input[*in_pos..], avail, symbol_limit)?;
-                produced += decoded;
-                *in_pos += pos;
-                self.total_in += pos as u64;
-                consumed += pos;
-            }
-        }
-
-        // What is left is too short to start a symbol from, so take it into the
-        // carry.
-        if !carry_blocked && !self.end_reached {
-            let rest = input.len() - *in_pos;
-            if rest > 0 && rest < IN_REQUIRED {
-                debug_assert_eq!(self.carry_len, 0);
-                self.carry[..rest].copy_from_slice(&input[*in_pos..]);
-                self.carry_len = rest;
-                *in_pos = input.len();
-                self.total_in += rest as u64;
-                consumed += rest;
-            }
-        }
-
-        // Decode the carry against zero padding and require the stream to end
-        // inside the real bytes.
-        if action == Action::Finish && !self.end_reached && *in_pos >= input.len() {
-            produced += self.decode_finish_tail()?;
-        }
-
-        Ok((consumed, produced))
-    }
-
-    /// Decodes what is left of the carry with padding zeros behind it, so the
-    /// decoder still sees the 20 bytes it needs to start one more symbol.
-    ///
-    /// The carry bytes were counted as consumed when they were taken in, so this
-    /// adds nothing to `bytes_consumed`.
-    fn decode_finish_tail(&mut self) -> crate::Result<usize> {
-        if room_for(self.lz.as_ref(), self.remaining_size) == 0 {
-            // No output space, so we cannot yet tell whether the stream really
-            // ends here. The caller has to drain first.
-            return Ok(0);
-        }
-
-        let carry_len = self.carry_len;
-
-        // One symbol may start at `pos == carry_len` and read up to
-        // `IN_REQUIRED` bytes from there, so at least that many zeros follow.
-        let mut scratch = [0u8; CARRY_CAP + IN_REQUIRED + 1];
-        scratch[..carry_len].copy_from_slice(&self.carry[..carry_len]);
-        let padded_len = carry_len + IN_REQUIRED + 1;
-        let (pos, produced) = self.run(&scratch[..padded_len], carry_len, carry_len + 1)?;
-
-        if pos > carry_len {
-            // The decoder had to read padding to get here, so the input is
-            // really truncated.
-            return Err(error_invalid_data("truncated LZMA stream"));
-        }
-
-        // Padding bytes must never be written back into the carry.
-        self.carry.copy_within(pos..carry_len, 0);
-        self.carry_len = carry_len - pos;
-
-        Ok(produced)
-    }
-
-    /// Decodes as much as fits from `buf`, returning `(read position, bytes
-    /// decoded into the dictionary)`.
-    fn run(
-        &mut self,
-        buf: &[u8],
-        real_len: usize,
-        symbol_limit: usize,
-    ) -> crate::Result<(usize, usize)> {
-        // `lz` and `lzma` stay borrowed while `rc` lives, so the fields are
-        // destructured up front and the range coder state is written back in
-        // exactly one place below, error paths included.
         let Self {
             lz,
             lzma,
-            rc: rc_state,
-            remaining_size,
-            end_reached,
+            core,
+            limits,
             ..
         } = self;
-
-        let room = room_for(lz.as_ref(), *remaining_size);
-        if room == 0 {
-            return Ok((0, 0));
-        }
 
         let (lz, lzma) = match (lz.as_mut(), lzma.as_mut()) {
             (Some(lz), Some(lzma)) => (lz, lzma),
             _ => return Err(error_invalid_data("LZMA decoder not initialized")),
         };
 
-        let pos_before = lz.get_pos();
-        lz.set_limit(room);
+        let (consumed, produced) = core.feed(lz, lzma, &input[*in_pos..], limits, action)?;
+        *in_pos += consumed;
+        self.total_in += consumed as u64;
 
-        let mut rc = RangeDecoder::from_parts(
-            SliceRangeReader::new(buf, real_len, symbol_limit),
-            *rc_state,
-        );
-        let decode_result = lzma.decode(lz, &mut rc);
-
-        // Must be read before anything can flush: `flush_partial` wraps `pos`
-        // back to zero once the dictionary is full and fully drained.
-        let produced = lz.get_pos() - pos_before;
-
-        let mut error = None;
-        if let Err(decode_error) = decode_result {
-            // An end of payload marker surfaces as an error, because the decoder
-            // calls `lz.repeat(0xFFFF_FFFF, len)`, which fails with "dist
-            // overflow". Anything else is genuine corruption. Check the order:
-            // `end_marker_detected()` is only meaningful right after a failed
-            // `repeat`.
-            if *remaining_size != u64::MAX || !lzma.end_marker_detected() {
-                error = Some(decode_error);
-            } else {
-                if rc.can_normalize() {
-                    rc.normalize();
-                }
-                // Only once the stream is known to end cleanly, or a caller that
-                // calls again after the error is told it did.
-                if rc.is_stream_finished() {
-                    *end_reached = true;
-                } else {
-                    error = Some(error_invalid_data("LZMA stream not properly terminated"));
-                }
-            }
-        }
-
-        // The reported position is only ever compared against buffer bounds:
-        // the assembly `decode_direct_bits` advances `pos` past what a symbol
-        // logically needed and clamps its reads instead of signalling.
-        let pos = rc.inner().pos().min(buf.len());
-        *rc_state = rc.state();
-
-        if let Some(error) = error {
-            return Err(error);
-        }
-
-        if *remaining_size <= u64::MAX / 2 {
-            *remaining_size -= produced as u64;
-            if *remaining_size == 0 {
-                *end_reached = true;
-            }
-        }
-
-        if *end_reached && lz.has_pending() {
-            return Err(error_invalid_data("end reached but not decoder finished"));
-        }
-
-        Ok((pos, produced))
+        Ok((consumed, produced))
     }
 }
 

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -846,6 +846,7 @@ impl LzmaStream {
             return Err(error_unsupported("only one filter is supported"));
         }
         let Some(config) = filters.first() else {
+            self.filter = None;
             return Ok(());
         };
         self.filter = Some(StreamFilter::new(config)?);
@@ -869,8 +870,7 @@ impl LzmaStream {
 
     /// Returns true if there is decoded output waiting to be flushed.
     pub fn has_output(&self) -> bool {
-        self.lz.as_ref().is_some_and(|lz| lz.has_output())
-            || self.filter_pos < self.filter_buf.len()
+        self.lz.as_ref().is_some_and(|lz| lz.has_output()) || self.filter_pos < self.settled_end()
     }
 
     /// Bytes that were absorbed from the caller but turned out not to belong to

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -293,6 +293,10 @@ const IN_REQUIRED: usize = 20;
 /// straight out of the caller's buffer.
 const CARRY_CAP: usize = 2 * IN_REQUIRED;
 
+/// Bytes the range coder needs to initialise: one zero byte and `code` as four
+/// big endian bytes. An LZMA2 chunk spends these out of its compressed size.
+pub(crate) const RC_INIT_SIZE: usize = 5;
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum LzmaState {
     Header,

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -338,6 +338,23 @@ pub(crate) struct Limits {
     pub(crate) end_reached: bool,
 }
 
+/// Whether anything follows the input a decode pass was given, and if not, what
+/// said so.
+///
+/// The two ends are not the same failure. A caller that has run out of bytes
+/// may simply have been handed a stream that was cut short, while a length
+/// field that does not cover its own payload is part of a stream that arrived
+/// whole and disagrees with itself.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputEnd {
+    /// More input can still follow.
+    More,
+    /// The caller said this is the last of the input.
+    Caller,
+    /// A length field in the stream says the payload ends here.
+    Length,
+}
+
 /// The part of an LZMA1 decode that has to survive between `process()` calls,
 /// minus the dictionary and the probability model it works on.
 ///
@@ -396,18 +413,19 @@ impl LzmaCore {
     /// Runs one decode pass over `input`, returning `(bytes consumed from
     /// input, bytes decoded into the dictionary)`.
     ///
-    /// `input_ends_here` says that nothing follows this slice, so the last
-    /// bytes of it may be decoded against zero padding. LZMA1 knows that from
-    /// the action the caller gave it; an LZMA2 chunk knows it from the
-    /// compressed size in its own header.
+    /// `input_end` says whether anything follows this slice, and if not, who
+    /// said so. The last bytes of the slice are then decoded against zero
+    /// padding, and a symbol that reaches into that padding is an error of
+    /// whichever kind the end came from.
     pub(crate) fn feed(
         &mut self,
         lz: &mut LzDecoder,
         lzma: &mut LzmaDecoder,
         input: &[u8],
         limits: &mut Limits,
-        input_ends_here: bool,
+        input_end: InputEnd,
     ) -> crate::Result<(usize, usize)> {
+        let input_ends_here = input_end != InputEnd::More;
         // Clamp before anything decides where a symbol may start, so no symbol
         // can reach a byte the budget does not cover. An LZMA2 chunk is
         // followed by the next chunk's header, and `SliceRangeReader` cannot
@@ -495,7 +513,7 @@ impl LzmaCore {
         // Decode the carry against zero padding and require the stream to end
         // inside the real bytes.
         if input_ends_here && !limits.end_reached && in_pos >= input.len() {
-            produced += self.decode_finish_tail(lz, lzma, limits)?;
+            produced += self.decode_finish_tail(lz, lzma, limits, input_end)?;
         }
 
         Ok((in_pos, produced))
@@ -511,6 +529,7 @@ impl LzmaCore {
         lz: &mut LzDecoder,
         lzma: &mut LzmaDecoder,
         limits: &mut Limits,
+        input_end: InputEnd,
     ) -> crate::Result<usize> {
         if room_for(lz, limits.remaining_size) == 0 {
             // No output space, so we cannot yet tell whether the stream really
@@ -535,9 +554,18 @@ impl LzmaCore {
         )?;
 
         if pos > carry_len {
-            // The decoder had to read padding to get here, so the input is
-            // really truncated.
-            return Err(error_eof("truncated LZMA stream"));
+            // The decoder had to read padding to get here, so a symbol runs
+            // past the end of the input. What that means depends on who said
+            // where the end was.
+            return Err(match input_end {
+                // A length field in the stream. Everything it declared is
+                // here, and the data inside it does not fit, so the data is
+                // wrong rather than missing.
+                InputEnd::Length => error_invalid_data("LZMA symbol runs past the compressed size"),
+                // The caller. More bytes would have finished the symbol, so
+                // the stream was cut short.
+                _ => error_eof("truncated LZMA stream"),
+            });
         }
 
         // Padding bytes must never be written back into the carry.
@@ -1242,10 +1270,13 @@ impl LzmaStream {
 
         // For LZMA1 the caller is the only one who knows whether more input is
         // coming, and `Action::Finish` is how it says so.
-        let input_ends_here = action == Action::Finish;
+        let input_end = if action == Action::Finish {
+            InputEnd::Caller
+        } else {
+            InputEnd::More
+        };
 
-        let (consumed, produced) =
-            core.feed(lz, lzma, &input[*in_pos..], limits, input_ends_here)?;
+        let (consumed, produced) = core.feed(lz, lzma, &input[*in_pos..], limits, input_end)?;
         *in_pos += consumed;
         self.total_in += consumed as u64;
 
@@ -1320,7 +1351,7 @@ mod tests {
         // Four bytes of a nineteen byte payload on offer: only four may be
         // taken, and they are too few to start a symbol from.
         let (consumed, produced) = core
-            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, false)
+            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, InputEnd::More)
             .unwrap();
         assert_eq!(consumed, 4);
         assert_eq!(produced, 0);
@@ -1328,7 +1359,7 @@ mod tests {
 
         // A used up budget stops the core dead, however much input is left.
         let (consumed, produced) = core
-            .feed(&mut lz, &mut lzma, &RAW[9..], &mut limits, false)
+            .feed(&mut lz, &mut lzma, &RAW[9..], &mut limits, InputEnd::More)
             .unwrap();
         assert_eq!(consumed, 0);
         assert_eq!(produced, 0);
@@ -1340,7 +1371,7 @@ mod tests {
         let mut limits = limits(None);
 
         let (consumed, produced) = core
-            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, true)
+            .feed(&mut lz, &mut lzma, &RAW[5..], &mut limits, InputEnd::Caller)
             .unwrap();
         assert_eq!(consumed, RAW.len() - 5);
         assert_eq!(produced, 13);

--- a/src/range_dec.rs
+++ b/src/range_dec.rs
@@ -492,7 +492,11 @@ impl RangeReader for SliceRangeReader<'_> {
     }
 
     fn try_read_u8(&mut self) -> crate::Result<u8> {
-        let byte = self.buf.get(self.pos).copied().ok_or_else(error_eof)?;
+        let byte = self
+            .buf
+            .get(self.pos)
+            .copied()
+            .ok_or_else(|| error_eof("unexpected end of range coder input"))?;
         self.pos += 1;
         Ok(byte)
     }
@@ -635,7 +639,10 @@ impl RangeReader for RangeDecoderBuffer {
     }
 
     fn try_read_u8(&mut self) -> crate::Result<u8> {
-        self.buf.get(self.pos).copied().ok_or_else(error_eof)
+        self.buf
+            .get(self.pos)
+            .copied()
+            .ok_or_else(|| error_eof("unexpected end of range coder input"))
     }
 
     #[inline(always)]

--- a/src/xz.rs
+++ b/src/xz.rs
@@ -25,9 +25,10 @@ use crate::{
     ByteReader, Read,
     crc::{Crc32, Crc64},
     error_invalid_data, error_invalid_input,
+    filter::FilterType,
 };
 #[cfg(feature = "encoder")]
-use crate::{ByteWriter, Write};
+use crate::{ByteWriter, Write, filter::FilterConfig};
 #[cfg(feature = "std")]
 use crate::{
     Lzma2Reader,
@@ -77,89 +78,6 @@ struct Block {
     uncompressed_size: u64,
 }
 
-/// Configuration for a filter in the XZ filter chain.
-#[derive(Debug, Clone)]
-pub struct FilterConfig {
-    /// Filter type to use.
-    pub filter_type: FilterType,
-    /// Property to use.
-    pub property: u32,
-}
-
-impl FilterConfig {
-    /// Creates a new delta filter configuration.
-    pub fn new_delta(distance: u32) -> Self {
-        Self {
-            filter_type: FilterType::Delta,
-            property: distance,
-        }
-    }
-
-    /// Creates a new BCJ x86 filter configuration.
-    pub fn new_bcj_x86(start_pos: u32) -> Self {
-        Self {
-            filter_type: FilterType::BcjX86,
-            property: start_pos,
-        }
-    }
-
-    /// Creates a new BCJ ARM filter configuration.
-    pub fn new_bcj_arm(start_pos: u32) -> Self {
-        Self {
-            filter_type: FilterType::BcjArm,
-            property: start_pos,
-        }
-    }
-
-    /// Creates a new BCJ ARM Thumb filter configuration.
-    pub fn new_bcj_arm_thumb(start_pos: u32) -> Self {
-        Self {
-            filter_type: FilterType::BcjArmThumb,
-            property: start_pos,
-        }
-    }
-
-    /// Creates a new BCJ ARM64 filter configuration.
-    pub fn new_bcj_arm64(start_pos: u32) -> Self {
-        Self {
-            filter_type: FilterType::BcjArm64,
-            property: start_pos,
-        }
-    }
-
-    /// Creates a new BCJ IA64 filter configuration.
-    pub fn new_bcj_ia64(start_pos: u32) -> Self {
-        Self {
-            filter_type: FilterType::BcjIa64,
-            property: start_pos,
-        }
-    }
-
-    /// Creates a new BCJ PPC filter configuration.
-    pub fn new_bcj_ppc(start_pos: u32) -> Self {
-        Self {
-            filter_type: FilterType::BcjPpc,
-            property: start_pos,
-        }
-    }
-
-    /// Creates a new BCJ SPARC filter configuration.
-    pub fn new_bcj_sparc(start_pos: u32) -> Self {
-        Self {
-            filter_type: FilterType::BcjSparc,
-            property: start_pos,
-        }
-    }
-
-    /// Creates a new BCJ RISC-V filter configuration.
-    pub fn new_bcj_risc_v(start_pos: u32) -> Self {
-        Self {
-            filter_type: FilterType::BcjRiscv,
-            property: start_pos,
-        }
-    }
-}
-
 /// Supported checksum types in XZ format.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CheckType {
@@ -192,51 +110,6 @@ impl CheckType {
             CheckType::Crc32 => 4,
             CheckType::Crc64 => 8,
             CheckType::Sha256 => 32,
-        }
-    }
-}
-
-/// Supported filter types in XZ format.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum FilterType {
-    /// Delta filter
-    Delta,
-    /// BCJ x86 filter
-    BcjX86,
-    /// BCJ PowerPC filter
-    BcjPpc,
-    /// BCJ IA64 filter
-    BcjIa64,
-    /// BCJ ARM filter
-    BcjArm,
-    /// BCJ ARM Thumb
-    BcjArmThumb,
-    /// BCJ SPARC filter
-    BcjSparc,
-    /// BCJ ARM64 filter
-    BcjArm64,
-    /// BCJ RISC-V filter
-    BcjRiscv,
-    /// LZMA2 filter
-    Lzma2,
-}
-
-impl TryFrom<u64> for FilterType {
-    type Error = ();
-
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        match value {
-            0x03 => Ok(FilterType::Delta),
-            0x04 => Ok(FilterType::BcjX86),
-            0x05 => Ok(FilterType::BcjPpc),
-            0x06 => Ok(FilterType::BcjIa64),
-            0x07 => Ok(FilterType::BcjArm),
-            0x08 => Ok(FilterType::BcjArmThumb),
-            0x09 => Ok(FilterType::BcjSparc),
-            0x0A => Ok(FilterType::BcjArm64),
-            0x0B => Ok(FilterType::BcjRiscv),
-            0x21 => Ok(FilterType::Lzma2),
-            _ => Err(()),
         }
     }
 }

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -1,14 +1,15 @@
 use alloc::{boxed::Box, vec::Vec};
 
 use super::{
-    BlockHeader, CheckType, ChecksumCalculator, FilterType, Index, IndexRecord, StreamFooter,
-    StreamHeader, XZ_FOOTER_MAGIC, XZ_MAGIC, count_multibyte_integer_size, parse_multibyte_integer,
+    BlockHeader, CheckType, ChecksumCalculator, Index, IndexRecord, StreamFooter, StreamHeader,
+    XZ_FOOTER_MAGIC, XZ_MAGIC, count_multibyte_integer_size, parse_multibyte_integer,
 };
 use crate::{
     CountingReader, Lzma2Reader, Read, Result,
     crc::Crc32,
     error_eof, error_invalid_data, error_out_of_memory,
     filter::{
+        FilterType,
         bcj::{BcjFilter, BcjReader},
         delta::{Delta, DeltaReader},
     },

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -7,12 +7,12 @@ use super::{
 use crate::{
     CountingReader, Lzma2Reader, Read, Result,
     crc::Crc32,
-    error_invalid_data,
+    error_invalid_data, error_out_of_memory,
     filter::{
         bcj::{BcjFilter, BcjReader},
         delta::{Delta, DeltaReader},
     },
-    lzma2_reader::Lzma2Stream,
+    lzma2_reader::{Lzma2Stream, get_stream_memory_usage},
     stream::{Action, Status, StreamResult},
 };
 
@@ -539,6 +539,8 @@ pub struct XzStream {
     index_crc: Crc32,
     index_size: usize,
     allow_multiple_streams: bool,
+    /// Memory usage limit in KiB. `u32::MAX` means no limit.
+    mem_limit_kb: u32,
     /// Set once `process()` has returned an error. A failed stream stays failed.
     failed: bool,
     total_in: u64,
@@ -570,6 +572,7 @@ impl XzStream {
             index_crc: Crc32::new(),
             index_size: 0,
             allow_multiple_streams,
+            mem_limit_kb: u32::MAX,
             failed: false,
             total_in: 0,
             total_out: 0,
@@ -577,6 +580,23 @@ impl XzStream {
             filter_buf: Vec::new(),
             filter_pos: 0,
             filter_unfiltered: 0,
+        }
+    }
+
+    /// Create a new XZ stream decoder with a memory usage limit.
+    ///
+    /// If `allow_multiple_streams` is true, concatenated XZ streams are decoded
+    /// sequentially until EOF.
+    /// - `mem_limit_kb` - memory usage limit in kibibytes (KiB). `u32::MAX` means no limit.
+    ///
+    /// Each block header is checked against the limit as it is parsed, so
+    /// violations surface from [`process()`] rather than from here.
+    ///
+    /// [`process()`]: XzStream::process
+    pub fn new_mem_limit(allow_multiple_streams: bool, mem_limit_kb: u32) -> Self {
+        Self {
+            mem_limit_kb,
+            ..Self::new(allow_multiple_streams)
         }
     }
 
@@ -1024,7 +1044,18 @@ impl XzStream {
             return Err(error_invalid_data("no LZMA2 filter in block"));
         }
 
-        self.lzma2 = Some(Lzma2Stream::new(lzma2_dict_size));
+        // Check the memory limit before allocating anything.
+        let need_mem = get_stream_memory_usage(lzma2_dict_size);
+        if self.mem_limit_kb < need_mem {
+            return Err(error_out_of_memory(
+                "needed memory too big for mem_limit_kb",
+            ));
+        }
+
+        self.lzma2 = Some(Lzma2Stream::new_mem_limit(
+            lzma2_dict_size,
+            self.mem_limit_kb,
+        ));
         if let Some(ct) = self.check_type {
             self.checksum = Some(ChecksumCalculator::new(ct));
         }

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     CountingReader, Lzma2Reader, Read, Result,
     crc::Crc32,
-    error_invalid_data, error_out_of_memory,
+    error_eof, error_invalid_data, error_out_of_memory,
     filter::{
         bcj::{BcjFilter, BcjReader},
         delta::{Delta, DeltaReader},
@@ -698,7 +698,7 @@ impl XzStream {
                                     self.state = XzStreamState::Finished;
                                     continue;
                                 }
-                                return Err(error_invalid_data("unexpected end of XZ stream"));
+                                return Err(error_eof("unexpected end of XZ stream"));
                             }
                             return Ok(StreamResult {
                                 bytes_consumed: in_pos,

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -8,11 +8,7 @@ use crate::{
     CountingReader, Lzma2Reader, Read, Result,
     crc::Crc32,
     error_eof, error_invalid_data, error_out_of_memory,
-    filter::{
-        FilterType,
-        bcj::{BcjFilter, BcjReader},
-        delta::{Delta, DeltaReader},
-    },
+    filter::{FilterConfig, FilterType, StreamFilter, bcj::BcjReader, delta::DeltaReader},
     lzma2_reader::{Lzma2Stream, get_stream_memory_usage},
     stream::{Action, Status, StreamResult},
 };
@@ -441,62 +437,6 @@ impl<R: Read> Read for XzReader<R> {
     }
 }
 
-enum StreamFilter {
-    Delta(Box<Delta>),
-    Bcj(BcjFilter),
-}
-
-impl StreamFilter {
-    fn from_filter_type(ft: FilterType, property: u32) -> Option<Self> {
-        match ft {
-            FilterType::Delta => Some(StreamFilter::Delta(Box::new(Delta::new(property as usize)))),
-            FilterType::BcjX86 => Some(StreamFilter::Bcj(BcjFilter::new_x86(
-                property as usize,
-                false,
-            ))),
-            FilterType::BcjArm => Some(StreamFilter::Bcj(BcjFilter::new_arm(
-                property as usize,
-                false,
-            ))),
-            FilterType::BcjArm64 => Some(StreamFilter::Bcj(BcjFilter::new_arm64(
-                property as usize,
-                false,
-            ))),
-            FilterType::BcjArmThumb => Some(StreamFilter::Bcj(BcjFilter::new_arm_thumb(
-                property as usize,
-                false,
-            ))),
-            FilterType::BcjPpc => Some(StreamFilter::Bcj(BcjFilter::new_power_pc(
-                property as usize,
-                false,
-            ))),
-            FilterType::BcjSparc => Some(StreamFilter::Bcj(BcjFilter::new_sparc(
-                property as usize,
-                false,
-            ))),
-            FilterType::BcjIa64 => Some(StreamFilter::Bcj(BcjFilter::new_ia64(
-                property as usize,
-                false,
-            ))),
-            FilterType::BcjRiscv => Some(StreamFilter::Bcj(BcjFilter::new_riscv(
-                property as usize,
-                false,
-            ))),
-            FilterType::Lzma2 => None,
-        }
-    }
-
-    fn apply_decode(&mut self, buf: &mut [u8]) -> usize {
-        match self {
-            StreamFilter::Delta(d) => {
-                d.decode(buf);
-                buf.len()
-            }
-            StreamFilter::Bcj(b) => b.code(buf),
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 enum XzStreamState {
     StreamHeader,
@@ -549,7 +489,6 @@ pub struct XzStream {
     filter: Option<StreamFilter>,
     filter_buf: Vec<u8>,
     filter_pos: usize,
-    filter_unfiltered: usize,
 }
 
 impl XzStream {
@@ -580,7 +519,6 @@ impl XzStream {
             filter: None,
             filter_buf: Vec::new(),
             filter_pos: 0,
-            filter_unfiltered: 0,
         }
     }
 
@@ -804,7 +742,7 @@ impl XzStream {
             return Ok(0);
         }
 
-        if self.filter_pos < self.filter_buf.len() - self.filter_unfiltered {
+        if self.filter_pos < self.filter_buf.len() - self.filter_held_back() {
             return self.emit_filtered_output(output, out_pos);
         }
 
@@ -836,7 +774,7 @@ impl XzStream {
     }
 
     fn emit_filtered_output(&mut self, output: &mut [u8], out_pos: &mut usize) -> Result<usize> {
-        let ready_end = self.filter_buf.len() - self.filter_unfiltered;
+        let ready_end = self.filter_buf.len() - self.filter_held_back();
         let available = ready_end - self.filter_pos;
         let space = output.len() - *out_pos;
         let n = available.min(space);
@@ -871,17 +809,17 @@ impl XzStream {
         lzma2.drain_to_buf(&mut self.filter_buf, 4096);
         let new_bytes = self.filter_buf.len() - prev_len;
         if new_bytes > 0 {
-            let filter_start = prev_len - self.filter_unfiltered;
+            let filter_start = prev_len - self.filter_held_back();
             let filter_slice = &mut self.filter_buf[filter_start..];
-            let filtered = self.filter.as_mut().unwrap().apply_decode(filter_slice);
-            self.filter_unfiltered = filter_slice.len() - filtered;
+            self.filter.as_mut().unwrap().decode(filter_slice);
         }
         new_bytes
     }
 
     fn compact_filter_buf(&mut self) {
-        if self.filter_unfiltered > 0 {
-            let tail_start = self.filter_buf.len() - self.filter_unfiltered;
+        let held_back = self.filter_held_back();
+        if held_back > 0 {
+            let tail_start = self.filter_buf.len() - held_back;
             let pending: Vec<u8> = self.filter_buf[tail_start..].to_vec();
             self.filter_buf.clear();
             self.filter_buf.extend_from_slice(&pending);
@@ -889,12 +827,11 @@ impl XzStream {
             self.filter_buf.clear();
         }
         self.filter_pos = 0;
-        self.filter_unfiltered = self.filter_buf.len();
     }
 
     fn try_complete_filtered_block(&mut self) -> Result<usize> {
         self.flush_filter_pending();
-        if self.filter_pos < self.filter_buf.len() - self.filter_unfiltered {
+        if self.filter_pos < self.filter_buf.len() - self.filter_held_back() {
             return Ok(1);
         }
         self.filter.take();
@@ -902,8 +839,14 @@ impl XzStream {
         Ok(1)
     }
 
+    fn filter_held_back(&self) -> usize {
+        self.filter.as_ref().map_or(0, |filter| filter.held_back())
+    }
+
     fn flush_filter_pending(&mut self) {
-        self.filter_unfiltered = 0;
+        if let Some(filter) = self.filter.as_mut() {
+            filter.finish();
+        }
     }
 
     fn finish_lzma2_block(&mut self) -> Result<()> {
@@ -1030,14 +973,17 @@ impl XzStream {
                 if ft == FilterType::Lzma2 {
                     lzma2_dict_size = properties[i];
                     found_lzma2 = true;
-                } else if let Some(f) = StreamFilter::from_filter_type(ft, properties[i]) {
+                } else {
                     // TODO: Support multiple filters for sans-I/O API.
                     if pre_filter.is_some() {
                         return Err(error_invalid_data(
                             "multiple non-LZMA2 filters not supported yet for stream API",
                         ));
                     }
-                    pre_filter = Some(f);
+                    pre_filter = Some(StreamFilter::new(&FilterConfig {
+                        filter_type: ft,
+                        property: properties[i],
+                    })?);
                 }
             }
         }
@@ -1063,7 +1009,6 @@ impl XzStream {
         self.filter = pre_filter;
         self.filter_buf.clear();
         self.filter_pos = 0;
-        self.filter_unfiltered = 0;
         self.block_count += 1;
         self.block_header_size = header_size as u64;
         self.block_compressed_size = 0;

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -539,6 +539,8 @@ pub struct XzStream {
     index_crc: Crc32,
     index_size: usize,
     allow_multiple_streams: bool,
+    /// Set once `process()` has returned an error. A failed stream stays failed.
+    failed: bool,
     total_in: u64,
     total_out: u64,
     filter: Option<StreamFilter>,
@@ -568,6 +570,7 @@ impl XzStream {
             index_crc: Crc32::new(),
             index_size: 0,
             allow_multiple_streams,
+            failed: false,
             total_in: 0,
             total_out: 0,
             filter: None,
@@ -600,6 +603,23 @@ impl XzStream {
     /// Returns how many bytes were consumed/produced and the stream status.
     /// Call repeatedly until `Status::StreamEnd` is returned.
     pub fn process(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        action: Action,
+    ) -> Result<StreamResult> {
+        if self.failed {
+            return Err(error_invalid_data("XZ stream already failed"));
+        }
+
+        let result = self.process_inner(input, output, action);
+        if result.is_err() {
+            self.failed = true;
+        }
+        result
+    }
+
+    fn process_inner(
         &mut self,
         input: &[u8],
         output: &mut [u8],

--- a/src/xz/writer.rs
+++ b/src/xz/writer.rs
@@ -2,14 +2,14 @@ use alloc::{boxed::Box, vec::Vec};
 use core::num::NonZeroU64;
 
 use super::{
-    CheckType, ChecksumCalculator, FilterConfig, FilterType, IndexRecord, add_padding,
-    write_xz_block_header, write_xz_index, write_xz_stream_footer, write_xz_stream_header,
+    CheckType, ChecksumCalculator, IndexRecord, add_padding, write_xz_block_header, write_xz_index,
+    write_xz_stream_footer, write_xz_stream_header,
 };
 use crate::{
     AutoFinish, AutoFinisher, CountingWriter, Lzma2Options, Result, Write,
     enc::{Lzma2Writer, LzmaOptions},
     error_invalid_data, error_invalid_input,
-    filter::{bcj::BcjWriter, delta::DeltaWriter},
+    filter::{FilterConfig, FilterType, bcj::BcjWriter, delta::DeltaWriter},
 };
 
 #[allow(clippy::large_enum_variant)]

--- a/src/xz/writer_mt.rs
+++ b/src/xz/writer_mt.rs
@@ -8,13 +8,15 @@ use std::{
 };
 
 use super::{
-    CheckType, ChecksumCalculator, FilterConfig, FilterType, IndexRecord, add_padding,
-    write_xz_block_header, write_xz_index, write_xz_stream_footer, write_xz_stream_header,
+    CheckType, ChecksumCalculator, IndexRecord, add_padding, write_xz_block_header, write_xz_index,
+    write_xz_stream_footer, write_xz_stream_header,
 };
 use crate::{
     AutoFinish, AutoFinisher, Lzma2Options, Result, XzOptions,
     enc::{Lzma2Writer, LzmaOptions},
-    error_invalid_input, set_error,
+    error_invalid_input,
+    filter::{FilterConfig, FilterType},
+    set_error,
     work_pool::{WorkPool, WorkPoolConfig},
     work_queue::WorkerHandle,
 };

--- a/tests/lzip_stream.rs
+++ b/tests/lzip_stream.rs
@@ -572,7 +572,9 @@ fn empty_input_errors() {
     let error = stream
         .process(&[], &mut output, Action::Finish)
         .unwrap_err();
-    assert_eq!(error.kind(), ErrorKind::InvalidData);
+    // The member header never arrived, so the input ended early rather than
+    // being wrong.
+    assert_eq!(error.kind(), ErrorKind::UnexpectedEof);
 }
 
 #[test]

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -4,7 +4,13 @@ use std::{
     io::{Read, Write},
 };
 
-use lzma_rust2::{Action, Lzma2Options, Lzma2Stream, Lzma2Writer, Status};
+use lzma_rust2::{
+    Action, FilterConfig, FilterType, Lzma2Options, Lzma2Reader, Lzma2Stream, Lzma2Writer, Status,
+    filter::{
+        bcj::{BcjReader, BcjWriter},
+        delta::{DeltaReader, DeltaWriter},
+    },
+};
 
 static APACHE2: &str = "tests/data/apache2.txt";
 static EXECUTABLE: &str = "tests/data/executable.exe";
@@ -860,4 +866,240 @@ fn truncation_reports_unexpected_eof() {
         );
         assert_eq!(stream_kind, reader_kind, "cut {cut}: decoders disagree");
     }
+}
+
+/// The filters worth trying: delta, which holds nothing back, and BCJ variants
+/// that hold back a different number of bytes each.
+fn filters() -> Vec<FilterConfig> {
+    vec![
+        FilterConfig::new_delta(1),
+        FilterConfig::new_delta(4),
+        FilterConfig::new_bcj_x86(0),
+        FilterConfig::new_bcj_arm64(0),
+        FilterConfig::new_bcj_ia64(0),
+    ]
+}
+
+/// Encodes `data` through the filter and then LZMA2, the way an XZ block with
+/// that filter chain would.
+fn compress_filtered(data: &[u8], filter: &FilterConfig, preset: u32) -> (Vec<u8>, u32) {
+    let opts = Lzma2Options::with_preset(preset);
+    let dict_size = opts.lzma_options.dict_size;
+    let lzma2 = Lzma2Writer::new(Vec::new(), opts);
+    let property = filter.property as usize;
+
+    let compressed = if filter.filter_type == FilterType::Delta {
+        let mut writer = DeltaWriter::new(lzma2, property);
+        writer.write_all(data).unwrap();
+        // The delta writer holds nothing back, so there is nothing to finish.
+        writer.into_inner().finish().unwrap()
+    } else {
+        let mut writer = match filter.filter_type {
+            FilterType::BcjX86 => BcjWriter::new_x86(lzma2, property),
+            FilterType::BcjArm64 => BcjWriter::new_arm64(lzma2, property),
+            FilterType::BcjIa64 => BcjWriter::new_ia64(lzma2, property),
+            other => panic!("no writer for {other:?}"),
+        };
+        writer.write_all(data).unwrap();
+        // Only `finish()` writes out the tail the filter held back.
+        writer.finish().unwrap().finish().unwrap()
+    };
+
+    (compressed, dict_size)
+}
+
+/// Decodes with the blocking reader chain, which this has to agree with.
+fn decompress_filtered(compressed: &[u8], filter: &FilterConfig, dict_size: u32) -> Vec<u8> {
+    let lzma2 = Lzma2Reader::new(compressed, dict_size, None);
+    let property = filter.property as usize;
+    let mut decompressed = Vec::new();
+
+    if filter.filter_type == FilterType::Delta {
+        DeltaReader::new(lzma2, property)
+            .read_to_end(&mut decompressed)
+            .unwrap();
+    } else {
+        let mut reader = match filter.filter_type {
+            FilterType::BcjX86 => BcjReader::new_x86(lzma2, property),
+            FilterType::BcjArm64 => BcjReader::new_arm64(lzma2, property),
+            FilterType::BcjIa64 => BcjReader::new_ia64(lzma2, property),
+            other => panic!("no reader for {other:?}"),
+        };
+        reader.read_to_end(&mut decompressed).unwrap();
+    }
+
+    decompressed
+}
+
+fn filtered_stream(dict_size: u32, filter: &FilterConfig) -> Lzma2Stream {
+    let mut stream = Lzma2Stream::new(dict_size);
+    stream.set_filters(std::slice::from_ref(filter)).unwrap();
+    stream
+}
+
+/// Real machine code, so the BCJ filters have something to convert.
+fn executable(len: usize) -> Vec<u8> {
+    std::fs::read(EXECUTABLE).unwrap()[..len].to_vec()
+}
+
+/// The sans-I/O decoder and the blocking reader chain have to give the same
+/// bytes for the same filtered stream.
+#[test]
+fn filtered_round_trip_matches_the_reader_chain() {
+    let data = executable(2 * 1024 * 1024);
+
+    for filter in filters() {
+        let kind = filter.filter_type;
+        let (compressed, dict_size) = compress_filtered(&data, &filter, 1);
+
+        let from_stream = decode(
+            filtered_stream(dict_size, &filter),
+            &compressed,
+            ENTIRE,
+            4096,
+        )
+        .unwrap_or_else(|error| panic!("{kind:?}: {error}"));
+        let from_reader = decompress_filtered(&compressed, &filter, dict_size);
+
+        assert!(from_stream == from_reader, "{kind:?}: decoders disagree");
+        assert!(from_stream == data, "{kind:?}");
+    }
+}
+
+/// A filter that holds a tail back only gets it wrong where a buffer boundary
+/// splits an instruction, so both sides have to be varied.
+#[test]
+fn filtered_chunk_matrix() {
+    let data = executable(32 * 1024);
+
+    for filter in filters() {
+        let kind = filter.filter_type;
+        let (compressed, dict_size) = compress_filtered(&data, &filter, 1);
+
+        for &chunk in CHUNK_SIZES {
+            for &out_size in OUTPUT_SIZES {
+                let decompressed = decode(
+                    filtered_stream(dict_size, &filter),
+                    &compressed,
+                    chunk,
+                    out_size,
+                )
+                .unwrap_or_else(|error| panic!("{kind:?} chunk {chunk} out {out_size}: {error}"));
+                assert!(
+                    decompressed == data,
+                    "{kind:?} chunk {chunk} out {out_size}"
+                );
+            }
+        }
+    }
+}
+
+/// The same, over an input long enough for several LZMA2 chunks. The filter
+/// runs on for the whole stream, while every chunk restarts the range coder.
+#[test]
+fn filtered_chunk_matrix_across_chunk_boundaries() {
+    let data = executable(300 * 1024);
+
+    for filter in [FilterConfig::new_delta(4), FilterConfig::new_bcj_x86(0)] {
+        let kind = filter.filter_type;
+        let (compressed, dict_size) = compress_filtered(&data, &filter, 1);
+        assert!(
+            chunk_ends(&compressed).len() > 2,
+            "expected more than one compressed chunk"
+        );
+
+        for &chunk in &[1usize, 5, 19, 20, 21, 39, 40, 41, 4096, ENTIRE] {
+            for &out_size in &[7usize, 4096] {
+                let decompressed = decode(
+                    filtered_stream(dict_size, &filter),
+                    &compressed,
+                    chunk,
+                    out_size,
+                )
+                .unwrap_or_else(|error| panic!("{kind:?} chunk {chunk} out {out_size}: {error}"));
+                assert!(
+                    decompressed == data,
+                    "{kind:?} chunk {chunk} out {out_size}"
+                );
+            }
+        }
+    }
+}
+
+/// `total_out()` counts what the caller was handed. A filtered stream decodes
+/// into a staging buffer on the way, and those bytes must not count twice, nor
+/// count before they arrive.
+#[test]
+fn filtered_total_out_counts_delivered_bytes() {
+    let data = executable(64 * 1024);
+    let filter = FilterConfig::new_bcj_x86(0);
+    let (compressed, dict_size) = compress_filtered(&data, &filter, 1);
+
+    let mut stream = filtered_stream(dict_size, &filter);
+    let mut output = [0u8; 100];
+    let mut decompressed = Vec::new();
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = stream
+            .process(&compressed[in_pos..], &mut output, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+
+        // Checked after every call, not just at the end: at this point the
+        // staging buffer holds decoded bytes the caller has not seen yet.
+        assert_eq!(stream.total_out(), decompressed.len() as u64);
+
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    assert!(decompressed == data);
+    assert_eq!(stream.total_out(), data.len() as u64);
+}
+
+/// The three ways of asking for something `set_filters` will not do.
+#[test]
+fn set_filters_rejects_what_it_can_not_do() {
+    // LZMA2 is the stage this type already is, not a pre-filter.
+    let mut stream = Lzma2Stream::new(4096);
+    let error = stream
+        .set_filters(&[FilterConfig {
+            filter_type: FilterType::Lzma2,
+            property: 4096,
+        }])
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+
+    // One pre-filter only, so a chain is refused rather than half applied.
+    let mut stream = Lzma2Stream::new(4096);
+    let error = stream
+        .set_filters(&[FilterConfig::new_delta(1), FilterConfig::new_bcj_x86(0)])
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+
+    // Too late: what came out until now came out unfiltered.
+    let mut stream = Lzma2Stream::new(4096);
+    let mut output = [0u8; 64];
+    stream.process(HELLO, &mut output, Action::Finish).unwrap();
+    let error = stream
+        .set_filters(&[FilterConfig::new_bcj_x86(0)])
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+/// An empty chain is not one of them: it leaves the stream unfiltered, so a
+/// caller can pass on whatever it was given.
+#[test]
+fn set_filters_accepts_an_empty_chain() {
+    let mut stream = Lzma2Stream::new(4096);
+    stream.set_filters(&[]).unwrap();
+    assert!(decode(stream, HELLO, ENTIRE, 4096).unwrap() == b"Hello, world!");
 }

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -773,3 +773,61 @@ fn failed_stream_stays_failed() {
 
     assert!(!stream.is_finished());
 }
+
+/// What a stream with the given dictionary size needs, in KiB: the decoder
+/// state plus the dictionary, and no range decoder buffer.
+fn stream_memory(dict_size: u32) -> u32 {
+    40 + dict_size / 1024
+}
+
+#[test]
+fn memory_limit_is_enforced_from_process() {
+    let mut output = [0u8; 64];
+
+    // The constructor cannot fail; the limit is checked once the dictionary is
+    // about to be allocated.
+    let mut stream = Lzma2Stream::new_mem_limit(4096, 1);
+    let error = stream
+        .process(HELLO, &mut output, Action::Finish)
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::OutOfMemory);
+
+    // A generous limit works on the same bytes.
+    let stream = Lzma2Stream::new_mem_limit(4096, u32::MAX);
+    assert!(decode(stream, HELLO, ENTIRE, 4096).unwrap() == b"Hello, world!");
+}
+
+#[test]
+fn memory_limit_does_not_count_a_range_decoder_buffer() {
+    let mut output = [0u8; 64];
+    let needed = stream_memory(4096);
+
+    // What the blocking reader needs is larger, because it buffers a whole
+    // compressed chunk before decoding it.
+    assert!(lzma_rust2::lzma2_get_memory_usage(4096) > needed);
+
+    let stream = Lzma2Stream::new_mem_limit(4096, needed);
+    assert!(decode(stream, HELLO, ENTIRE, 4096).unwrap() == b"Hello, world!");
+
+    let mut stream = Lzma2Stream::new_mem_limit(4096, needed - 1);
+    let error = stream
+        .process(HELLO, &mut output, Action::Finish)
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::OutOfMemory);
+}
+
+#[test]
+fn a_stream_that_broke_the_limit_stays_broken() {
+    let mut output = [0u8; 64];
+    let mut stream = Lzma2Stream::new_mem_limit(4096, 1);
+
+    let error = stream
+        .process(HELLO, &mut output, Action::Finish)
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::OutOfMemory);
+
+    let error = stream
+        .process(HELLO, &mut output, Action::Finish)
+        .unwrap_err();
+    assert!(error.to_string().contains("already failed"));
+}

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -1006,6 +1006,61 @@ fn executable(len: usize) -> Vec<u8> {
     std::fs::read(EXECUTABLE).unwrap()[..len].to_vec()
 }
 
+/// A filled slice replaces whatever filter was set, so an empty one has to as
+/// well. Otherwise the two calls mean different things and the doc comment is
+/// only true for a stream that never had a filter.
+#[test]
+fn an_empty_slice_clears_a_filter_that_was_set() {
+    let data = executable(64 * 1024);
+    let filter = FilterConfig::new_bcj_x86(0);
+    let (compressed, dict_size) = compress_filtered(&data, &filter, 6);
+
+    // What an unfiltered stream gives back: the BCJ encoded bytes, which have
+    // to differ from the plain text or this proves nothing.
+    let unfiltered = decode(Lzma2Stream::new(dict_size), &compressed, ENTIRE, 4096).unwrap();
+    assert_ne!(unfiltered, data);
+
+    let mut stream = Lzma2Stream::new(dict_size);
+    stream.set_filters(std::slice::from_ref(&filter)).unwrap();
+    stream.set_filters(&[]).unwrap();
+
+    let decoded = decode(stream, &compressed, ENTIRE, 4096).unwrap();
+    assert_eq!(decoded, unfiltered, "the earlier filter was left in place");
+}
+
+/// `has_output()` says whether bytes can be had right now. A BCJ filter holds
+/// its last bytes back until it sees what follows them, and those cannot be
+/// handed over, so a caller that drains while `has_output()` is true has to get
+/// something every time or it never stops.
+#[test]
+fn has_output_only_reports_bytes_that_can_be_had() {
+    let data = executable(64 * 1024);
+
+    for filter in filters() {
+        let (compressed, dict_size) = compress_filtered(&data, &filter, 6);
+        for out_size in OUTPUT_SIZES {
+            let mut stream = filtered_stream(dict_size, &filter);
+            let mut output = vec![0u8; *out_size];
+
+            // Feed all but the last of the input, so the stream cannot
+            // reach its end and settle the tail on its own. Draining without
+            // feeding more is what a caller emptying the stream before its
+            // next read does.
+            let head = &compressed[..compressed.len() - 1];
+            stream.process(head, &mut output, Action::Run).unwrap();
+
+            while stream.has_output() {
+                let result = stream.process(&[], &mut output, Action::Run).unwrap();
+                assert!(
+                    result.bytes_produced > 0,
+                    "{:?} out {out_size}: has_output() was true but the call gave nothing",
+                    filter.filter_type
+                );
+            }
+        }
+    }
+}
+
 /// The sans-I/O decoder and the blocking reader chain have to give the same
 /// bytes for the same filtered stream.
 #[test]

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -749,6 +749,70 @@ fn chunk_declaring_unread_bytes_is_rejected() {
     }
 }
 
+/// Raises the uncompressed size a chunk header declares, leaving every other
+/// byte alone. The stream stays complete; it just disagrees with itself.
+fn raise_first_chunk_size(compressed: &[u8], extra: u32) -> Vec<u8> {
+    let mut out = compressed.to_vec();
+    let control = out[0];
+    assert!(control >= 0x80, "first chunk is not an LZMA chunk");
+    let declared = (((control & 0x1F) as u32) << 16 | (out[1] as u32) << 8 | out[2] as u32) + 1;
+    let raised = declared + extra - 1;
+    out[0] = (control & 0xE0) | ((raised >> 16) as u8 & 0x1F);
+    out[1] = (raised >> 8) as u8;
+    out[2] = raised as u8;
+    out
+}
+
+/// A chunk whose header claims more uncompressed bytes than its payload holds
+/// is corrupt, not truncated: every byte the stream declared is present.
+///
+/// The distinction matters to a caller that retries on `UnexpectedEof` and
+/// rejects on anything else. Reporting this as `UnexpectedEof` would have it
+/// wait for bytes that are never coming.
+#[test]
+fn chunk_declaring_too_much_output_is_corrupt_not_truncated() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (compressed, dict_size) = compress(&data, 6);
+
+    // The untouched stream has to decode, or the rest proves nothing.
+    decode(Lzma2Stream::new(dict_size), &compressed, ENTIRE, 4096).unwrap();
+
+    let corrupt = raise_first_chunk_size(&compressed, 4000);
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let error = decode(Lzma2Stream::new(dict_size), &corrupt, chunk, out_size)
+                .expect_err("a chunk that asks for more output than it has must be rejected");
+            assert_eq!(
+                error.kind(),
+                std::io::ErrorKind::InvalidData,
+                "chunk {chunk} out {out_size}: complete but corrupt stream reported as {:?}",
+                error.kind()
+            );
+        }
+    }
+}
+
+/// The contrast to the test above: a stream that really was cut short still
+/// reports `UnexpectedEof`, which is what the caller needs to tell the two
+/// apart.
+#[test]
+fn a_cut_short_stream_still_reports_eof() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (compressed, dict_size) = compress(&data, 6);
+
+    for missing in [1usize, 20, 100] {
+        let truncated = &compressed[..compressed.len() - missing];
+        let error = decode(Lzma2Stream::new(dict_size), truncated, ENTIRE, 4096)
+            .expect_err("a truncated stream must be rejected");
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::UnexpectedEof,
+            "missing {missing} bytes: truncated stream reported as {:?}",
+            error.kind()
+        );
+    }
+}
+
 /// "Hello, world!" as one uncompressed LZMA2 chunk that resets the dictionary,
 /// followed by the end of stream control byte.
 static HELLO: &[u8] = &[

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -941,6 +941,8 @@ fn filters() -> Vec<FilterConfig> {
         FilterConfig::new_bcj_x86(0),
         FilterConfig::new_bcj_arm64(0),
         FilterConfig::new_bcj_ia64(0),
+        FilterConfig::new_bcj_arm_thumb(0),
+        FilterConfig::new_bcj_risc_v(0),
     ]
 }
 
@@ -962,6 +964,8 @@ fn compress_filtered(data: &[u8], filter: &FilterConfig, preset: u32) -> (Vec<u8
             FilterType::BcjX86 => BcjWriter::new_x86(lzma2, property),
             FilterType::BcjArm64 => BcjWriter::new_arm64(lzma2, property),
             FilterType::BcjIa64 => BcjWriter::new_ia64(lzma2, property),
+            FilterType::BcjArmThumb => BcjWriter::new_arm_thumb(lzma2, property),
+            FilterType::BcjRiscv => BcjWriter::new_riscv(lzma2, property),
             other => panic!("no writer for {other:?}"),
         };
         writer.write_all(data).unwrap();
@@ -987,6 +991,8 @@ fn decompress_filtered(compressed: &[u8], filter: &FilterConfig, dict_size: u32)
             FilterType::BcjX86 => BcjReader::new_x86(lzma2, property),
             FilterType::BcjArm64 => BcjReader::new_arm64(lzma2, property),
             FilterType::BcjIa64 => BcjReader::new_ia64(lzma2, property),
+            FilterType::BcjArmThumb => BcjReader::new_arm_thumb(lzma2, property),
+            FilterType::BcjRiscv => BcjReader::new_riscv(lzma2, property),
             other => panic!("no reader for {other:?}"),
         };
         reader.read_to_end(&mut decompressed).unwrap();

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -742,3 +742,34 @@ fn chunk_declaring_unread_bytes_is_rejected() {
         }
     }
 }
+
+/// "Hello, world!" as one uncompressed LZMA2 chunk that resets the dictionary,
+/// followed by the end of stream control byte.
+static HELLO: &[u8] = &[
+    1, 0, 12, 72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33, 0,
+];
+
+/// A control byte in the reserved 0x03 to 0x7F range.
+static RESERVED_CONTROL: &[u8] = &[0x03];
+
+/// Once `process()` has returned an error the stream is done, however good the
+/// bytes handed to it after that are.
+#[test]
+fn failed_stream_stays_failed() {
+    let mut stream = Lzma2Stream::new(4096);
+    let mut output = [0u8; 64];
+
+    let error = stream
+        .process(RESERVED_CONTROL, &mut output, Action::Run)
+        .unwrap_err();
+    assert!(!error.to_string().contains("already failed"));
+
+    // The same stream gets nowhere now, even on bytes that decode fine on their
+    // own.
+    let error = stream
+        .process(HELLO, &mut output, Action::Finish)
+        .unwrap_err();
+    assert!(error.to_string().contains("already failed"));
+
+    assert!(!stream.is_finished());
+}

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -831,3 +831,33 @@ fn a_stream_that_broke_the_limit_stays_broken() {
         .unwrap_err();
     assert!(error.to_string().contains("already failed"));
 }
+
+/// A truncated stream is the end of the input, not bad data. The blocking
+/// reader has always said so; the sans-I/O decoder has to agree, or the same
+/// file gets two different answers depending on which one you reached for.
+#[test]
+fn truncation_reports_unexpected_eof() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (compressed, dict_size) = compress(&data, 6);
+
+    for cut in [1usize, 7, 64, compressed.len() / 2, compressed.len() - 1] {
+        let truncated = &compressed[..cut];
+
+        let mut from_reader = Vec::new();
+        let reader_kind = lzma_rust2::Lzma2Reader::new(truncated, dict_size, None)
+            .read_to_end(&mut from_reader)
+            .map(|_| None)
+            .unwrap_or_else(|error| Some(error.kind()));
+
+        let stream_kind = decode(Lzma2Stream::new(dict_size), truncated, ENTIRE, 4096)
+            .map(|_| None)
+            .unwrap_or_else(|error| Some(error.kind()));
+
+        assert_eq!(
+            stream_kind,
+            Some(std::io::ErrorKind::UnexpectedEof),
+            "cut {cut}: expected UnexpectedEof from Lzma2Stream"
+        );
+        assert_eq!(stream_kind, reader_kind, "cut {cut}: decoders disagree");
+    }
+}

--- a/tests/lzma2_stream.rs
+++ b/tests/lzma2_stream.rs
@@ -1,7 +1,12 @@
-use std::io::{Read, Write};
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    cell::Cell,
+    io::{Read, Write},
+};
 
 use lzma_rust2::{Action, Lzma2Options, Lzma2Stream, Lzma2Writer, Status};
 
+static APACHE2: &str = "tests/data/apache2.txt";
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
 static PG6800: &str = "tests/data/pg6800.txt";
@@ -380,4 +385,360 @@ fn uncompressed_chunk_exceeds_dict() {
     }
     assert_eq!(decompressed.len(), original.len());
     assert_eq!(decompressed, original);
+}
+
+/// Chunk size meaning "hand over everything that is left".
+const ENTIRE: usize = usize::MAX;
+
+/// The 19/20/21 rows straddle the 20 bytes one LZMA symbol can need, the
+/// 39/40/41 rows straddle the carry capacity, and 4 and 6 split the five byte
+/// range coder init that starts every compressed chunk.
+const CHUNK_SIZES: &[usize] = &[1, 2, 3, 4, 5, 6, 19, 20, 21, 39, 40, 41, 4096, ENTIRE];
+const OUTPUT_SIZES: &[usize] = &[1, 7, 4096];
+
+fn compress(data: &[u8], preset: u32) -> (Vec<u8>, u32) {
+    let opts = Lzma2Options::with_preset(preset);
+    let dict_size = opts.lzma_options.dict_size;
+    let mut writer = Lzma2Writer::new(Vec::new(), opts);
+    writer.write_all(data).unwrap();
+    (writer.finish().unwrap(), dict_size)
+}
+
+/// Walks the chunk headers, returning the offset just past every chunk, the
+/// end of stream marker included.
+fn chunk_ends(compressed: &[u8]) -> Vec<usize> {
+    let mut ends = Vec::new();
+    let mut pos = 0;
+    loop {
+        let control = compressed[pos];
+        if control == 0x00 {
+            ends.push(pos + 1);
+            return ends;
+        }
+        if control >= 0x80 {
+            let header = if control >= 0xC0 { 6 } else { 5 };
+            let compressed_size =
+                u16::from_be_bytes([compressed[pos + 3], compressed[pos + 4]]) as usize + 1;
+            pos += header + compressed_size;
+        } else {
+            let size = u16::from_be_bytes([compressed[pos + 1], compressed[pos + 2]]) as usize + 1;
+            pos += 3 + size;
+        }
+        ends.push(pos);
+    }
+}
+
+/// Drives a stream to completion, feeding at most `chunk` bytes and accepting at
+/// most `out_size` bytes per call.
+fn decode(
+    mut stream: Lzma2Stream,
+    compressed: &[u8],
+    chunk: usize,
+    out_size: usize,
+) -> std::io::Result<Vec<u8>> {
+    let mut decompressed = Vec::new();
+    let mut output = vec![0u8; out_size];
+    let mut pos = 0usize;
+
+    loop {
+        let end = pos.saturating_add(chunk).min(compressed.len());
+        let action = if end >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+
+        let result = stream.process(&compressed[pos..end], &mut output, action)?;
+        pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+
+        if result.status == Status::StreamEnd {
+            assert!(stream.is_finished());
+            assert_eq!(stream.total_out(), decompressed.len() as u64);
+            return Ok(decompressed);
+        }
+
+        // Neither consuming nor producing anything while output space is
+        // available is a stall: the caller would loop forever.
+        assert!(
+            result.bytes_consumed != 0 || result.bytes_produced != 0,
+            "stalled at input {pos}/{} after {} bytes of output",
+            compressed.len(),
+            decompressed.len()
+        );
+    }
+}
+
+fn test_chunk_matrix(data: &[u8], preset: u32) {
+    let (compressed, dict_size) = compress(data, preset);
+    for &chunk in CHUNK_SIZES {
+        for &out_size in OUTPUT_SIZES {
+            let decompressed = decode(Lzma2Stream::new(dict_size), &compressed, chunk, out_size)
+                .unwrap_or_else(|error| {
+                    panic!("preset {preset} chunk {chunk} out {out_size}: {error}")
+                });
+            assert!(
+                decompressed == data,
+                "preset {preset} chunk {chunk} out {out_size}"
+            );
+        }
+    }
+}
+
+#[test]
+fn chunk_matrix_apache2() {
+    let data = std::fs::read(APACHE2).unwrap();
+    for preset in 0..=9 {
+        test_chunk_matrix(&data, preset);
+    }
+}
+
+#[test]
+fn chunk_matrix_input_html() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    for preset in 0..=9 {
+        test_chunk_matrix(&data, preset);
+    }
+}
+
+/// The chunk size matrix above fits in a single LZMA2 chunk, so it never splits
+/// a call across a chunk boundary. This one does: the input is big enough for
+/// several chunks, each of which restarts the range coder.
+#[test]
+fn chunk_matrix_across_chunk_boundaries() {
+    let data = std::fs::read(PG100).unwrap()[..300 * 1024].to_vec();
+    let (compressed, dict_size) = compress(&data, 1);
+    assert!(
+        chunk_ends(&compressed).len() > 2,
+        "expected more than one compressed chunk"
+    );
+
+    for &chunk in &[1usize, 5, 19, 20, 21, 39, 40, 41, 4096, ENTIRE] {
+        for &out_size in &[7usize, 4096] {
+            let decompressed = decode(Lzma2Stream::new(dict_size), &compressed, chunk, out_size)
+                .unwrap_or_else(|error| panic!("chunk {chunk} out {out_size}: {error}"));
+            assert!(decompressed == data, "chunk {chunk} out {out_size}");
+        }
+    }
+}
+
+/// The point of decoding chunks as they arrive: a chunk has to produce output
+/// before its last compressed byte has been handed over. Buffering the whole
+/// chunk first fails this.
+#[test]
+fn output_arrives_before_the_chunk_ends() {
+    let data = std::fs::read(PG100).unwrap()[..1024 * 1024].to_vec();
+    let (compressed, dict_size) = compress(&data, 6);
+    let first_chunk_end = chunk_ends(&compressed)[0];
+    assert!(
+        first_chunk_end > 60 * 1024,
+        "expected a chunk near the 64 KiB compressed maximum, got {first_chunk_end}"
+    );
+
+    let mut stream = Lzma2Stream::new(dict_size);
+    let mut output = vec![0u8; 4096];
+    let mut produced = 0;
+    let mut in_pos = 0;
+
+    // Everything but the last byte of the first chunk, one byte at a time.
+    while in_pos < first_chunk_end - 1 {
+        let end = in_pos + 1;
+        let result = stream
+            .process(&compressed[in_pos..end], &mut output, Action::Run)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        produced += result.bytes_produced;
+        assert!(
+            result.bytes_consumed != 0 || result.bytes_produced != 0,
+            "stalled at {in_pos}"
+        );
+    }
+
+    assert!(
+        produced > 0,
+        "no output before the last byte of the first chunk"
+    );
+}
+
+/// Truncation has to come back as an error rather than a stall or a silent
+/// short read, wherever the cut falls.
+#[test]
+fn truncation_is_rejected() {
+    let data = std::fs::read(PG100).unwrap()[..300 * 1024].to_vec();
+    let (compressed, dict_size) = compress(&data, 1);
+    let ends = chunk_ends(&compressed);
+    let first = ends[0];
+
+    let mut cuts = vec![1usize, 2, 3, 5, 6, 7, 8, 10, 11, 100, 1000];
+    // Inside the second chunk, including its header and range coder init.
+    cuts.extend([first + 1, first + 3, first + 6, first + 8, first + 30]);
+    cuts.push(first);
+
+    for cut in cuts {
+        assert!(cut < compressed.len());
+        let truncated = &compressed[..cut];
+        assert!(
+            decode(Lzma2Stream::new(dict_size), truncated, ENTIRE, 4096).is_err(),
+            "truncating to {cut} bytes was accepted"
+        );
+    }
+}
+
+/// `Action::Run` alone still ends the stream: the `0x00` control byte says so
+/// without any help from the caller.
+#[test]
+fn run_alone_reaches_stream_end() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (compressed, dict_size) = compress(&data, 1);
+
+    let mut stream = Lzma2Stream::new(dict_size);
+    let mut output = vec![0u8; 4096];
+    let mut decompressed = Vec::new();
+    let mut in_pos = 0;
+
+    loop {
+        let result = stream
+            .process(&compressed[in_pos..], &mut output, Action::Run)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+        assert!(result.bytes_consumed != 0 || result.bytes_produced != 0);
+    }
+
+    assert!(decompressed == data);
+    assert_eq!(in_pos, compressed.len());
+}
+
+/// `Action::Finish` on a stream that really is complete ends it, and on one cut
+/// short in any of the three places it can be cut short it errors.
+#[test]
+fn finish_semantics() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (compressed, dict_size) = compress(&data, 1);
+
+    let decompressed = decode(Lzma2Stream::new(dict_size), &compressed, ENTIRE, 4096).unwrap();
+    assert!(decompressed == data);
+
+    // Mid chunk header, mid range coder init, mid chunk payload.
+    for cut in [2usize, 8, 40] {
+        let mut stream = Lzma2Stream::new(dict_size);
+        let mut output = vec![0u8; 4096];
+        let mut in_pos = 0;
+        let mut errored = false;
+        for _ in 0..100 {
+            match stream.process(&compressed[in_pos..cut], &mut output, Action::Finish) {
+                Ok(result) => {
+                    in_pos += result.bytes_consumed;
+                    assert_ne!(
+                        result.status,
+                        Status::StreamEnd,
+                        "cut {cut} ended the stream"
+                    );
+                }
+                Err(_) => {
+                    errored = true;
+                    break;
+                }
+            }
+        }
+        assert!(errored, "Action::Finish accepted a stream cut at {cut}");
+    }
+}
+
+/// The compressed chunk is no longer buffered, so nothing 64 KiB sized may be
+/// allocated up front, and the dictionary stays lazy behind `ensure_capacity`.
+#[test]
+fn new_allocates_no_chunk_buffer() {
+    let before = allocated();
+    let stream = Lzma2Stream::new(1 << 24);
+    let after = allocated();
+    drop(stream);
+    assert!(
+        after - before < 4096,
+        "Lzma2Stream::new allocated {} bytes",
+        after - before
+    );
+}
+
+thread_local! {
+    /// Bytes this thread has asked the allocator for. Per thread, so tests
+    /// running side by side do not disturb each other.
+    static ALLOCATED: Cell<usize> = const { Cell::new(0) };
+}
+
+fn allocated() -> usize {
+    ALLOCATED.with(|counter| counter.get())
+}
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let _ = ALLOCATED.try_with(|counter| counter.set(counter.get() + layout.size()));
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let _ = ALLOCATED.try_with(|counter| {
+            counter.set(counter.get() + new_size.saturating_sub(layout.size()))
+        });
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static COUNTING: Counting = Counting;
+
+/// Grows the first chunk's declared compressed size by `junk` and pads its
+/// payload to match, so the chunk claims bytes no symbol will ever read.
+fn pad_first_chunk(compressed: &[u8], junk: usize) -> Vec<u8> {
+    assert!(compressed[0] >= 0x80, "not an LZMA chunk");
+    let header = if compressed[0] >= 0xC0 { 6 } else { 5 };
+    let declared = u16::from_be_bytes([compressed[3], compressed[4]]) as usize + 1;
+
+    let mut padded = compressed[..header].to_vec();
+    let grown = (declared + junk - 1) as u16;
+    padded[3] = (grown >> 8) as u8;
+    padded[4] = (grown & 0xFF) as u8;
+    padded.extend_from_slice(&compressed[header..header + declared]);
+    padded.extend(core::iter::repeat_n(0u8, junk));
+    padded.extend_from_slice(&compressed[header + declared..]);
+    padded
+}
+
+/// A chunk that declares more compressed bytes than its symbols read has to be
+/// rejected, however the caller slices the input.
+///
+/// The budget counts bytes taken in, and the last few of those can still be in
+/// the carry when it reaches zero, so a used up budget alone does not mean the
+/// chunk was really consumed. `Lzma2Reader` rejects these, and the two decoders
+/// have to agree.
+#[test]
+fn chunk_declaring_unread_bytes_is_rejected() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (compressed, dict_size) = compress(&data, 6);
+
+    // The unpadded stream has to decode, or the rest proves nothing.
+    decode(Lzma2Stream::new(dict_size), &compressed, ENTIRE, 4096).unwrap();
+
+    for junk in [1usize, 2, 5, 10, 19, 20] {
+        let padded = pad_first_chunk(&compressed, junk);
+        for &chunk in CHUNK_SIZES {
+            for &out_size in OUTPUT_SIZES {
+                let result = decode(Lzma2Stream::new(dict_size), &padded, chunk, out_size);
+                assert!(
+                    result.is_err(),
+                    "junk {junk} chunk {chunk} out {out_size}: accepted a chunk \
+                     with {junk} bytes the decoder never read"
+                );
+            }
+        }
+    }
 }

--- a/tests/lzma_stream.rs
+++ b/tests/lzma_stream.rs
@@ -729,6 +729,8 @@ fn filters() -> Vec<FilterConfig> {
         FilterConfig::new_bcj_x86(0),
         FilterConfig::new_bcj_arm64(0),
         FilterConfig::new_bcj_ia64(0),
+        FilterConfig::new_bcj_arm_thumb(0),
+        FilterConfig::new_bcj_risc_v(0),
     ]
 }
 
@@ -747,6 +749,8 @@ fn filter_through(lzma: LzmaWriter<Vec<u8>>, data: &[u8], filter: &FilterConfig)
             FilterType::BcjX86 => BcjWriter::new_x86(lzma, property),
             FilterType::BcjArm64 => BcjWriter::new_arm64(lzma, property),
             FilterType::BcjIa64 => BcjWriter::new_ia64(lzma, property),
+            FilterType::BcjArmThumb => BcjWriter::new_arm_thumb(lzma, property),
+            FilterType::BcjRiscv => BcjWriter::new_riscv(lzma, property),
             other => panic!("no writer for {other:?}"),
         };
         writer.write_all(data).unwrap();
@@ -817,6 +821,8 @@ fn decompress_filtered(
             FilterType::BcjX86 => BcjReader::new_x86(lzma, property),
             FilterType::BcjArm64 => BcjReader::new_arm64(lzma, property),
             FilterType::BcjIa64 => BcjReader::new_ia64(lzma, property),
+            FilterType::BcjArmThumb => BcjReader::new_arm_thumb(lzma, property),
+            FilterType::BcjRiscv => BcjReader::new_riscv(lzma, property),
             other => panic!("no reader for {other:?}"),
         };
         reader.read_to_end(&mut decompressed)?;

--- a/tests/lzma_stream.rs
+++ b/tests/lzma_stream.rs
@@ -1,6 +1,12 @@
 use std::io::{ErrorKind, Read, Write};
 
-use lzma_rust2::{Action, LzmaOptions, LzmaReader, LzmaStream, LzmaWriter, Status};
+use lzma_rust2::{
+    Action, FilterConfig, FilterType, LzmaOptions, LzmaReader, LzmaStream, LzmaWriter, Status,
+    filter::{
+        bcj::{BcjReader, BcjWriter},
+        delta::{DeltaReader, DeltaWriter},
+    },
+};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -712,4 +718,374 @@ fn a_non_zero_first_range_coder_byte_is_rejected() {
     compressed[0] = 0x01;
     let error = decode(raw_stream(raw), &compressed, ENTIRE, 4096).unwrap_err();
     assert_eq!(error.kind(), ErrorKind::InvalidInput);
+}
+
+/// The filters worth trying: delta, which holds nothing back, and BCJ variants
+/// that hold back a different number of bytes each.
+fn filters() -> Vec<FilterConfig> {
+    vec![
+        FilterConfig::new_delta(1),
+        FilterConfig::new_delta(4),
+        FilterConfig::new_bcj_x86(0),
+        FilterConfig::new_bcj_arm64(0),
+        FilterConfig::new_bcj_ia64(0),
+    ]
+}
+
+/// Writes `data` through the filter into `lzma` and returns what came out of
+/// the LZMA writer underneath it.
+fn filter_through(lzma: LzmaWriter<Vec<u8>>, data: &[u8], filter: &FilterConfig) -> Vec<u8> {
+    let property = filter.property as usize;
+
+    if filter.filter_type == FilterType::Delta {
+        let mut writer = DeltaWriter::new(lzma, property);
+        writer.write_all(data).unwrap();
+        // The delta writer holds nothing back, so there is nothing to finish.
+        writer.into_inner().finish().unwrap()
+    } else {
+        let mut writer = match filter.filter_type {
+            FilterType::BcjX86 => BcjWriter::new_x86(lzma, property),
+            FilterType::BcjArm64 => BcjWriter::new_arm64(lzma, property),
+            FilterType::BcjIa64 => BcjWriter::new_ia64(lzma, property),
+            other => panic!("no writer for {other:?}"),
+        };
+        writer.write_all(data).unwrap();
+        // Only `finish()` writes out the tail the filter held back.
+        writer.finish().unwrap().finish().unwrap()
+    }
+}
+
+/// Encodes `data` through the filter and then LZMA1, including the .lzma
+/// header.
+fn compress_filtered_header(
+    data: &[u8],
+    filter: &FilterConfig,
+    preset: u32,
+    known_size: bool,
+) -> Vec<u8> {
+    let options = LzmaOptions::with_preset(preset);
+    let size = known_size.then_some(data.len() as u64);
+    let lzma = LzmaWriter::new_use_header(Vec::new(), &options, size).unwrap();
+    filter_through(lzma, data, filter)
+}
+
+/// Encodes `data` through the filter and then raw LZMA1, which is the shape a
+/// filter chain without any container framing around it has.
+fn compress_filtered_raw(
+    data: &[u8],
+    filter: &FilterConfig,
+    preset: u32,
+    use_end_marker: bool,
+) -> (Vec<u8>, RawProps) {
+    let options = LzmaOptions::with_preset(preset);
+    let lzma = LzmaWriter::new_no_header(Vec::new(), &options, use_end_marker).unwrap();
+    let props = lzma.props();
+    let compressed = filter_through(lzma, data, filter);
+    (
+        compressed,
+        RawProps {
+            uncomp_size: if use_end_marker {
+                u64::MAX
+            } else {
+                data.len() as u64
+            },
+            props,
+            dict_size: options.dict_size,
+        },
+    )
+}
+
+/// Decodes with the blocking reader chain, which this has to agree with.
+fn decompress_filtered(
+    compressed: &[u8],
+    filter: &FilterConfig,
+    raw: Option<RawProps>,
+) -> std::io::Result<Vec<u8>> {
+    let lzma = match raw {
+        None => LzmaReader::new_mem_limit(compressed, u32::MAX, None)?,
+        Some(raw) => {
+            LzmaReader::new_with_props(compressed, raw.uncomp_size, raw.props, raw.dict_size, None)?
+        }
+    };
+    let property = filter.property as usize;
+    let mut decompressed = Vec::new();
+
+    if filter.filter_type == FilterType::Delta {
+        DeltaReader::new(lzma, property).read_to_end(&mut decompressed)?;
+    } else {
+        let mut reader = match filter.filter_type {
+            FilterType::BcjX86 => BcjReader::new_x86(lzma, property),
+            FilterType::BcjArm64 => BcjReader::new_arm64(lzma, property),
+            FilterType::BcjIa64 => BcjReader::new_ia64(lzma, property),
+            other => panic!("no reader for {other:?}"),
+        };
+        reader.read_to_end(&mut decompressed)?;
+    }
+
+    Ok(decompressed)
+}
+
+fn filtered_stream(mut stream: LzmaStream, filter: &FilterConfig) -> LzmaStream {
+    stream.set_filters(std::slice::from_ref(filter)).unwrap();
+    stream
+}
+
+/// Real machine code, so the BCJ filters have something to convert.
+fn executable(len: usize) -> Vec<u8> {
+    std::fs::read(EXECUTABLE).unwrap()[..len].to_vec()
+}
+
+/// The sans-I/O decoder and the blocking reader chain have to give the same
+/// bytes for the same filtered stream, in every mode LZMA1 comes in.
+#[test]
+fn filtered_round_trip_matches_the_reader_chain() {
+    let data = executable(256 * 1024);
+
+    for filter in filters() {
+        let kind = filter.filter_type;
+
+        // .lzma header, known uncompressed size.
+        let compressed = compress_filtered_header(&data, &filter, 1, true);
+        let from_stream = decode(
+            filtered_stream(LzmaStream::new_mem_limit(u32::MAX, None), &filter),
+            &compressed,
+            ENTIRE,
+            4096,
+        )
+        .unwrap_or_else(|error| panic!("{kind:?} header/known size: {error}"));
+        let from_reader = decompress_filtered(&compressed, &filter, None).unwrap();
+        assert!(from_stream == from_reader, "{kind:?} header/known size");
+        assert!(from_stream == data, "{kind:?} header/known size");
+
+        // .lzma header, unknown size, terminated by an end of payload marker.
+        let compressed = compress_filtered_header(&data, &filter, 1, false);
+        let from_stream = decode(
+            filtered_stream(LzmaStream::new_mem_limit(u32::MAX, None), &filter),
+            &compressed,
+            ENTIRE,
+            4096,
+        )
+        .unwrap_or_else(|error| panic!("{kind:?} header/EOPM: {error}"));
+        let from_reader = decompress_filtered(&compressed, &filter, None).unwrap();
+        assert!(from_stream == from_reader, "{kind:?} header/EOPM");
+        assert!(from_stream == data, "{kind:?} header/EOPM");
+
+        // Raw LZMA1 with an end of payload marker, which is what a raw filter
+        // chain looks like: no header, no declared size.
+        let (compressed, raw) = compress_filtered_raw(&data, &filter, 1, true);
+        let from_stream = decode(
+            filtered_stream(raw_stream(raw), &filter),
+            &compressed,
+            ENTIRE,
+            4096,
+        )
+        .unwrap_or_else(|error| panic!("{kind:?} raw/EOPM: {error}"));
+        let from_reader = decompress_filtered(&compressed, &filter, Some(raw)).unwrap();
+        assert!(from_stream == from_reader, "{kind:?} raw/EOPM");
+        assert!(from_stream == data, "{kind:?} raw/EOPM");
+
+        // Raw LZMA1 with a known size and no marker.
+        let (compressed, raw) = compress_filtered_raw(&data, &filter, 1, false);
+        let from_stream = decode(
+            filtered_stream(raw_stream(raw), &filter),
+            &compressed,
+            ENTIRE,
+            4096,
+        )
+        .unwrap_or_else(|error| panic!("{kind:?} raw/known size: {error}"));
+        let from_reader = decompress_filtered(&compressed, &filter, Some(raw)).unwrap();
+        assert!(from_stream == from_reader, "{kind:?} raw/known size");
+        assert!(from_stream == data, "{kind:?} raw/known size");
+    }
+}
+
+/// A filter that holds a tail back only gets it wrong where a buffer boundary
+/// splits an instruction, so both sides have to be varied.
+#[test]
+fn filtered_chunk_matrix() {
+    let data = executable(32 * 1024);
+
+    for filter in filters() {
+        let kind = filter.filter_type;
+
+        // Header mode, known size.
+        let compressed = compress_filtered_header(&data, &filter, 1, true);
+        for &chunk in CHUNK_SIZES {
+            for &out_size in OUTPUT_SIZES {
+                let decompressed = decode(
+                    filtered_stream(LzmaStream::new_mem_limit(u32::MAX, None), &filter),
+                    &compressed,
+                    chunk,
+                    out_size,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("{kind:?} header chunk {chunk} out {out_size}: {error}")
+                });
+                assert!(
+                    decompressed == data,
+                    "{kind:?} header chunk {chunk} out {out_size}"
+                );
+            }
+        }
+
+        // Raw mode with an end of payload marker, so the EOPM path gets the
+        // same treatment.
+        let (compressed, raw) = compress_filtered_raw(&data, &filter, 1, true);
+        for &chunk in CHUNK_SIZES {
+            for &out_size in OUTPUT_SIZES {
+                let decompressed = decode(
+                    filtered_stream(raw_stream(raw), &filter),
+                    &compressed,
+                    chunk,
+                    out_size,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("{kind:?} raw chunk {chunk} out {out_size}: {error}")
+                });
+                assert!(
+                    decompressed == data,
+                    "{kind:?} raw chunk {chunk} out {out_size}"
+                );
+            }
+        }
+    }
+}
+
+/// `total_out()` counts what the caller was handed. A filtered stream decodes
+/// into a staging buffer on the way, and those bytes must not count twice, nor
+/// count before they arrive.
+#[test]
+fn filtered_total_out_counts_delivered_bytes() {
+    let data = executable(64 * 1024);
+    let filter = FilterConfig::new_bcj_x86(0);
+    let (compressed, raw) = compress_filtered_raw(&data, &filter, 1, true);
+
+    let mut stream = filtered_stream(raw_stream(raw), &filter);
+    let mut output = [0u8; 100];
+    let mut decompressed = Vec::new();
+    let mut in_pos = 0;
+
+    loop {
+        let action = if in_pos >= compressed.len() {
+            Action::Finish
+        } else {
+            Action::Run
+        };
+        let result = stream
+            .process(&compressed[in_pos..], &mut output, action)
+            .unwrap();
+        in_pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+
+        // Checked after every call, not just at the end: at this point the
+        // staging buffer holds decoded bytes the caller has not seen yet.
+        assert_eq!(stream.total_out(), decompressed.len() as u64);
+
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    assert!(decompressed == data);
+    assert_eq!(stream.total_out(), data.len() as u64);
+}
+
+/// Bytes sitting in the staging buffer are output waiting to be flushed, the
+/// same as bytes still in the dictionary.
+#[test]
+fn filtered_has_output_reports_staged_bytes() {
+    let data = executable(200);
+    let filter = FilterConfig::new_bcj_x86(0);
+    let (compressed, raw) = compress_filtered_raw(&data, &filter, 1, true);
+
+    let mut stream = filtered_stream(raw_stream(raw), &filter);
+    let mut output = [0u8; 1];
+    let result = stream
+        .process(&compressed, &mut output, Action::Finish)
+        .unwrap();
+    assert_eq!(result.status, Status::Ok);
+
+    // Everything the dictionary held fits in one drain, so what is waiting now
+    // is waiting in the staging buffer.
+    assert!(stream.has_output());
+
+    let mut decompressed = output[..result.bytes_produced].to_vec();
+    loop {
+        let result = stream.process(&[], &mut output, Action::Finish).unwrap();
+        decompressed.extend_from_slice(&output[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+    }
+
+    assert!(decompressed == data);
+    assert!(!stream.has_output());
+}
+
+/// Filtering happens on the way out, so what the stream did not use up on the
+/// way in comes back unchanged.
+#[test]
+fn filtered_trailing_data_is_recoverable() {
+    let data = executable(64 * 1024);
+    let garbage: Vec<u8> = (0u8..=255).cycle().take(300).collect();
+    let filter = FilterConfig::new_bcj_x86(0);
+
+    for &chunk in CHUNK_SIZES {
+        let (compressed, raw) = compress_filtered_raw(&data, &filter, 1, true);
+        let mut input = compressed.clone();
+        input.extend_from_slice(&garbage);
+
+        let (decompressed, unused) =
+            decode_recovering_tail(filtered_stream(raw_stream(raw), &filter), &input, chunk)
+                .unwrap();
+
+        assert!(decompressed == data, "chunk {chunk}");
+        assert_eq!(unused, garbage, "chunk {chunk}");
+    }
+}
+
+/// The three ways of asking for something `set_filters` will not do.
+#[test]
+fn set_filters_rejects_what_it_can_not_do() {
+    // LZMA2 is a stage of its own, not a pre-filter.
+    let mut stream = LzmaStream::new_mem_limit(u32::MAX, None);
+    let error = stream
+        .set_filters(&[FilterConfig {
+            filter_type: FilterType::Lzma2,
+            property: 4096,
+        }])
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+
+    // One pre-filter only, so a chain is refused rather than half applied.
+    let mut stream = LzmaStream::new_mem_limit(u32::MAX, None);
+    let error = stream
+        .set_filters(&[FilterConfig::new_delta(1), FilterConfig::new_bcj_x86(0)])
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+
+    // Too late: what came out until now came out unfiltered.
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress_header(&data, 1, true);
+    let mut stream = LzmaStream::new_mem_limit(u32::MAX, None);
+    let mut output = [0u8; 64];
+    stream
+        .process(&compressed, &mut output, Action::Run)
+        .unwrap();
+    let error = stream
+        .set_filters(&[FilterConfig::new_bcj_x86(0)])
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidInput);
+}
+
+/// An empty chain is not one of them: it leaves the stream unfiltered, so a
+/// caller can pass on whatever it was given.
+#[test]
+fn set_filters_accepts_an_empty_chain() {
+    let data = std::fs::read(APACHE2).unwrap();
+    let compressed = compress_header(&data, 1, true);
+
+    let mut stream = LzmaStream::new_mem_limit(u32::MAX, None);
+    stream.set_filters(&[]).unwrap();
+    assert!(decode(stream, &compressed, ENTIRE, 4096).unwrap() == data);
 }

--- a/tests/lzma_stream.rs
+++ b/tests/lzma_stream.rs
@@ -835,6 +835,61 @@ fn executable(len: usize) -> Vec<u8> {
     std::fs::read(EXECUTABLE).unwrap()[..len].to_vec()
 }
 
+/// A filled slice replaces whatever filter was set, so an empty one has to as
+/// well. Otherwise the two calls mean different things and the doc comment is
+/// only true for a stream that never had a filter.
+#[test]
+fn an_empty_slice_clears_a_filter_that_was_set() {
+    let data = executable(64 * 1024);
+    let filter = FilterConfig::new_bcj_x86(0);
+    let (compressed, raw) = compress_filtered_raw(&data, &filter, 6, true);
+
+    // What an unfiltered stream gives back: the BCJ encoded bytes, which have
+    // to differ from the plain text or this proves nothing.
+    let unfiltered = decode(raw_stream(raw), &compressed, ENTIRE, 4096).unwrap();
+    assert_ne!(unfiltered, data);
+
+    let mut stream = raw_stream(raw);
+    stream.set_filters(std::slice::from_ref(&filter)).unwrap();
+    stream.set_filters(&[]).unwrap();
+
+    let decoded = decode(stream, &compressed, ENTIRE, 4096).unwrap();
+    assert_eq!(decoded, unfiltered, "the earlier filter was left in place");
+}
+
+/// `has_output()` says whether bytes can be had right now. A BCJ filter holds
+/// its last bytes back until it sees what follows them, and those cannot be
+/// handed over, so a caller that drains while `has_output()` is true has to get
+/// something every time or it never stops.
+#[test]
+fn has_output_only_reports_bytes_that_can_be_had() {
+    let data = executable(64 * 1024);
+
+    for filter in filters() {
+        let (compressed, raw) = compress_filtered_raw(&data, &filter, 6, true);
+        for out_size in OUTPUT_SIZES {
+            let mut stream = filtered_stream(raw_stream(raw), &filter);
+            let mut output = vec![0u8; *out_size];
+
+            // Feed all but the last of the input, so the stream cannot
+            // reach its end and settle the tail on its own. Draining without
+            // feeding more is what a caller emptying the stream before its
+            // next read does.
+            let head = &compressed[..compressed.len() - 1];
+            stream.process(head, &mut output, Action::Run).unwrap();
+
+            while stream.has_output() {
+                let result = stream.process(&[], &mut output, Action::Run).unwrap();
+                assert!(
+                    result.bytes_produced > 0,
+                    "{:?} out {out_size}: has_output() was true but the call gave nothing",
+                    filter.filter_type
+                );
+            }
+        }
+    }
+}
+
 /// The sans-I/O decoder and the blocking reader chain have to give the same
 /// bytes for the same filtered stream, in every mode LZMA1 comes in.
 #[test]

--- a/tests/xz_stream.rs
+++ b/tests/xz_stream.rs
@@ -528,3 +528,27 @@ fn decode_bcj_x86_byte_at_a_time() {
     assert_eq!(decompressed.len(), original.len());
     assert!(decompressed == original);
 }
+
+#[test]
+fn failed_stream_stays_failed() {
+    let compressed = encode_xz(b"Hello, world!", 6);
+    let mut broken = compressed.clone();
+    broken[0] ^= 0xFF;
+
+    let mut decoder = XzStream::new(false);
+    let mut output_buf = [0u8; 4096];
+
+    let error = decoder
+        .process(&broken, &mut output_buf, Action::Finish)
+        .unwrap_err();
+    assert!(!error.to_string().contains("already failed"));
+
+    // The same decoder gets nowhere now, even on bytes that decode fine on
+    // their own.
+    let error = decoder
+        .process(&compressed, &mut output_buf, Action::Finish)
+        .unwrap_err();
+    assert!(error.to_string().contains("already failed"));
+
+    assert!(decode_with_stream(&compressed) == b"Hello, world!");
+}

--- a/tests/xz_stream.rs
+++ b/tests/xz_stream.rs
@@ -552,3 +552,56 @@ fn failed_stream_stays_failed() {
 
     assert!(decode_with_stream(&compressed) == b"Hello, world!");
 }
+
+/// What a block with the given dictionary size needs, in KiB: the decoder state
+/// plus the dictionary, and no range decoder buffer.
+fn block_memory(dict_size: u32) -> u32 {
+    40 + dict_size / 1024
+}
+
+#[test]
+fn memory_limit_is_enforced_from_process() {
+    let compressed = encode_xz(b"Hello, world!", 6);
+    let mut output_buf = [0u8; 4096];
+
+    // The constructor cannot fail; the limit is checked once a block header has
+    // been parsed.
+    let mut decoder = XzStream::new_mem_limit(false, 1);
+    let error = decoder
+        .process(&compressed, &mut output_buf, Action::Finish)
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::OutOfMemory);
+
+    // A generous limit works on the same bytes.
+    assert!(decode_with_stream(&compressed) == b"Hello, world!");
+}
+
+#[test]
+fn memory_limit_matches_the_dictionary_in_the_block_header() {
+    let dict_size = XzOptions::with_preset(6).lzma_options.dict_size;
+    let compressed = encode_xz(b"Hello, world!", 6);
+    let needed = block_memory(dict_size);
+    let mut output_buf = [0u8; 4096];
+
+    let mut decoder = XzStream::new_mem_limit(false, needed);
+    let mut decompressed = Vec::new();
+    let mut pos = 0;
+    loop {
+        let result = decoder
+            .process(&compressed[pos..], &mut output_buf, Action::Finish)
+            .unwrap();
+        pos += result.bytes_consumed;
+        decompressed.extend_from_slice(&output_buf[..result.bytes_produced]);
+        if result.status == Status::StreamEnd {
+            break;
+        }
+        assert!(result.bytes_consumed != 0 || result.bytes_produced != 0);
+    }
+    assert!(decompressed == b"Hello, world!");
+
+    let mut decoder = XzStream::new_mem_limit(false, needed - 1);
+    let error = decoder
+        .process(&compressed, &mut output_buf, Action::Finish)
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::OutOfMemory);
+}


### PR DESCRIPTION
Previously, the sans-I/O decoder for LZMA2 (`Lzma2Stream`) worked by caching the whole LZMA chunk into memory (up to 64 KiB) before decoding any of it. However, with the new `LzmaStream` added in #109, we can re-use its core for `Lzma2Stream` instead, to reduce the cache size and help the decompressor produce output sooner.

This PR also fixes some minor bugs and add some new methods to the sans-I/O decoder so they could be used more easily.

Main changes in this PR:
- Extract the slice-decoding core of `LzmaStream` into `LzmaCore`. Also add a way to pass in the length of the compressed payload, so it stops at the end of an LZMA2 chunk instead of reading into the next chunk header. `LzmaStream` passes no length and is unaffected.
- Rework `Lzma2Stream` to decode through `LzmaCore` as input arrives, removing the chunk buffering.
- Fix the bug in `XzStream` and `Lzma2Stream` where an error from a previous `process()` could be "un-error" on later `process()` calls (similar to what we did with `LzmaStream`)
- Add a `new_mem_limit()` constructor to `XzStream` and `Lzma2Stream`.
- Use UnexpectedEof for truncated streams in sans/i-o decoders, matching the status code from the i/o decoders.
- Add `set_filters()` method to `Lzma2Stream` and `LzmaStream`, allowing users to use filters on these sans-i/o API.