### PR TITLE
Hand over an uncompressed chunk as it is copied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- An uncompressed LZMA2 chunk is now handed over as it is copied, instead of only once the dictionary fills.
+
 ## 0.20.0 - 2026-08-23
 
 ### Added

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -731,12 +731,10 @@ impl Lzma2Stream {
         let new_remaining = remaining - to_copy;
         if new_remaining == 0 {
             self.state = Lzma2State::DrainOutput;
-        } else if self.lz.available_space() == 0 {
-            self.state = Lzma2State::DrainUncompressed {
-                remaining: new_remaining,
-            };
         } else {
-            self.state = Lzma2State::UncompressedData {
+            // A copy reaches the caller before the next one starts, so the
+            // bytes are not left sitting in the dictionary.
+            self.state = Lzma2State::DrainUncompressed {
                 remaining: new_remaining,
             };
         }


### PR DESCRIPTION
An uncompressed LZMA2 chunk was copied into the dictionary until the dictionary ran out of space, and only then handed to the caller. Until that happened a call could take in a whole input buffer and return without producing anything.

Drain after every copy instead, so the bytes reach the caller in the same call that took them in.

Changes:
- In `process_uncompressed_data()`, jump to `DrainUncompressed` right away instead of waiting until the lz dictionary is full.