### PR TITLE
Reject invalid XZ headers and fix a mis-reported truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Lzma2ReaderMt` and `XzReaderMt` no longer degrade to single-threaded decoding.
+- `Lzma2Stream` and `XzStream` now decode the input they still hold back once the caller says the input ends, so corrupt
+  data in a chunk is reported as such instead of as a stream that was cut short.
 
 ## 0.20.1 - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The reserved bits of the XZ stream header flags are now all checked, and come back as `Unsupported` instead of
+  `InvalidData`. The format checksums those flags on their own so that a decoder can tell a corrupt file from one it
+  does not support, and a set reserved bit fits an `Unsupported` error better.
+
 ### Fixed
 
 - `Lzma2ReaderMt` and `XzReaderMt` no longer degrade to single-threaded decoding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Lzma2ReaderMt` and `XzReaderMt` no longer degrade to single-threaded decoding.
 - `Lzma2Stream` and `XzStream` now decode the input they still hold back once the caller says the input ends, so corrupt
   data in a chunk is reported as such instead of as a stream that was cut short.
+- Reject a block header that sets reserved flag bits, instead of decoding the block as if they meant nothing.
 
 ## 0.20.1 - 2026-08-30
 

--- a/src/lzma2_reader.rs
+++ b/src/lzma2_reader.rs
@@ -620,6 +620,28 @@ impl Lzma2Stream {
         // takes no input at all.
         if *in_pos >= input.len() && compressed_left > 0 {
             if action == Action::Finish {
+                // The input ends here. Let the core decode what it still holds
+                // back. Data that is already corrupt is then reported as
+                // corrupt and not as a stream that was cut short.
+                let produced = {
+                    let Self {
+                        lz,
+                        lzma,
+                        core,
+                        limits,
+                        ..
+                    } = self;
+                    match lzma.as_mut() {
+                        Some(lzma) => core.feed(lz, lzma, &[], limits, InputEnd::Caller)?.1,
+                        None => 0,
+                    }
+                };
+
+                if produced > 0 {
+                    self.state = Lzma2State::DrainCompressed;
+                    return Ok(None);
+                }
+
                 return Err(error_eof("unexpected end of LZMA2 stream"));
             }
             return Ok(Some(StreamResult {
@@ -649,6 +671,8 @@ impl Lzma2Stream {
         // not a stream that was cut short.
         let input_end = if compressed_left <= available.len() as u64 {
             InputEnd::Length
+        } else if action == Action::Finish {
+            InputEnd::Caller
         } else {
             InputEnd::More
         };

--- a/src/lzma_reader.rs
+++ b/src/lzma_reader.rs
@@ -458,8 +458,8 @@ impl LzmaCore {
 
             let symbol_limit = filled.saturating_sub(IN_REQUIRED - 1);
             let (pos, decoded) =
-                self.run(lz, lzma, limits, &scratch[..filled], filled, symbol_limit)?;
-            produced += decoded;
+                self.run(lz, lzma, limits, &scratch[..filled], filled, symbol_limit);
+            produced += decoded?;
 
             if pos >= carry_len {
                 // The carry is drained. Un-consume the scratch residue so the
@@ -486,8 +486,8 @@ impl LzmaCore {
                 // that is while `pos < avail - (IN_REQUIRED - 1)`.
                 let symbol_limit = avail - (IN_REQUIRED - 1);
                 let (pos, decoded) =
-                    self.run(lz, lzma, limits, &input[in_pos..], avail, symbol_limit)?;
-                produced += decoded;
+                    self.run(lz, lzma, limits, &input[in_pos..], avail, symbol_limit);
+                produced += decoded?;
                 in_pos += pos;
             }
         }
@@ -544,14 +544,14 @@ impl LzmaCore {
         let mut scratch = [0u8; CARRY_CAP + IN_REQUIRED + 1];
         scratch[..carry_len].copy_from_slice(&self.carry[..carry_len]);
         let padded_len = carry_len + IN_REQUIRED + 1;
-        let (pos, produced) = self.run(
+        let (pos, result) = self.run(
             lz,
             lzma,
             limits,
             &scratch[..padded_len],
             carry_len,
             carry_len + 1,
-        )?;
+        );
 
         if pos > carry_len {
             // The decoder had to read padding to get here, so a symbol runs
@@ -568,6 +568,8 @@ impl LzmaCore {
             });
         }
 
+        let produced = result?;
+
         // Padding bytes must never be written back into the carry.
         self.carry.copy_within(pos..carry_len, 0);
         self.carry_len = carry_len - pos;
@@ -575,8 +577,11 @@ impl LzmaCore {
         Ok(produced)
     }
 
-    /// Decodes as much as fits from `buf`, returning `(read position, bytes
-    /// decoded into the dictionary)`.
+    /// Decodes as much as fits from `buf`, returning the read position and
+    /// either the bytes decoded into the dictionary or why the decode failed.
+    ///
+    /// The position comes back even when the decode failed. A caller that
+    /// padded `buf` can then tell whether the padding was reached.
     fn run(
         &mut self,
         lz: &mut LzDecoder,
@@ -585,10 +590,10 @@ impl LzmaCore {
         buf: &[u8],
         real_len: usize,
         symbol_limit: usize,
-    ) -> crate::Result<(usize, usize)> {
+    ) -> (usize, crate::Result<usize>) {
         let room = room_for(lz, limits.remaining_size);
         if room == 0 {
-            return Ok((0, 0));
+            return (0, Ok(0));
         }
 
         let pos_before = lz.get_pos();
@@ -632,7 +637,7 @@ impl LzmaCore {
         self.rc = rc.state();
 
         if let Some(error) = error {
-            return Err(error);
+            return (pos, Err(error));
         }
 
         if limits.remaining_size <= u64::MAX / 2 {
@@ -643,10 +648,13 @@ impl LzmaCore {
         }
 
         if limits.end_reached && lz.has_pending() {
-            return Err(error_invalid_data("end reached but not decoder finished"));
+            return (
+                pos,
+                Err(error_invalid_data("end reached but not decoder finished")),
+            );
         }
 
-        Ok((pos, produced))
+        (pos, Ok(produced))
     }
 }
 

--- a/src/xz.rs
+++ b/src/xz.rs
@@ -24,7 +24,7 @@ pub use writer_mt::XzWriterMt;
 use crate::{
     ByteReader, Read,
     crc::{Crc32, Crc64},
-    error_invalid_data, error_invalid_input,
+    error_invalid_data, error_invalid_input, error_unsupported,
     filter::FilterType,
 };
 #[cfg(feature = "encoder")]
@@ -219,7 +219,28 @@ impl BlockHeader {
         let mut header_data = vec![0u8; header_size - 1];
         reader.read_exact(&mut header_data)?;
 
+        // The header carries its own checksum. It is verified first. A corrupt
+        // header is reported as corrupt and not as unsupported.
+        let crc_offset = header_data.len() - 4;
+        let expected_crc = u32::from_le_bytes([
+            header_data[crc_offset],
+            header_data[crc_offset + 1],
+            header_data[crc_offset + 2],
+            header_data[crc_offset + 3],
+        ]);
+        let mut crc = Crc32::new();
+        crc.update(&[header_size_encoded]);
+        crc.update(&header_data[..crc_offset]);
+        if expected_crc != crc.finalize() {
+            return Err(error_invalid_data("XZ block header CRC32 mismatch"));
+        }
+
         let block_flags = header_data[0];
+        // Bits 2-5 are reserved. A set bit means the header has an unknown
+        // field. It should not be parsed.
+        if block_flags & 0x3C != 0 {
+            return Err(error_unsupported("reserved block flag bits are set"));
+        }
         let num_filters = ((block_flags & 0x03) + 1) as usize;
         let has_compressed_size = (block_flags & 0x40) != 0;
         let has_uncompressed_size = (block_flags & 0x80) != 0;
@@ -415,22 +436,6 @@ impl BlockHeader {
             return Err(error_invalid_data("invalid XZ block header CRC32 position"));
         }
 
-        let expected_crc = u32::from_le_bytes([
-            header_data[offset],
-            header_data[offset + 1],
-            header_data[offset + 2],
-            header_data[offset + 3],
-        ]);
-
-        // Calculate CRC32 of header size byte + header data (excluding CRC32).
-        let mut crc = Crc32::new();
-        crc.update(&[header_size_encoded]);
-        crc.update(&header_data[..offset]);
-
-        if expected_crc != crc.finalize() {
-            return Err(error_invalid_data("XZ block header CRC32 mismatch"));
-        }
-
         Ok(Some(BlockHeader {
             header_size,
             compressed_size,
@@ -459,6 +464,11 @@ impl BlockHeader {
 
         let header_data = &block_data[1..header_size];
         let block_flags = header_data[0];
+        // Bits 2-5 are reserved. A set bit means the header has an unknown
+        // field. It should not be parsed.
+        if block_flags & 0x3C != 0 {
+            return Err(error_unsupported("reserved block flag bits are set"));
+        }
         let num_filters = ((block_flags & 0x03) + 1) as usize;
         let has_compressed_size = (block_flags & 0x40) != 0;
         let has_uncompressed_size = (block_flags & 0x80) != 0;

--- a/src/xz.rs
+++ b/src/xz.rs
@@ -99,7 +99,7 @@ impl CheckType {
             0x01 => Ok(CheckType::Crc32),
             0x04 => Ok(CheckType::Crc64),
             0x0A => Ok(CheckType::Sha256),
-            _ => Err(error_invalid_data("unsupported XZ check type")),
+            _ => Err(error_unsupported("unsupported XZ check type")),
         }
     }
 
@@ -731,17 +731,20 @@ impl StreamHeader {
         let mut flags = [0u8; 2];
         reader.read_exact(&mut flags)?;
 
-        if flags[0] != 0 {
-            return Err(error_invalid_data("invalid XZ stream flags"));
-        }
-
-        let check_type = CheckType::from_byte(flags[1])?;
-
         let expected_crc = reader.read_u32()?;
 
         if expected_crc != Crc32::checksum(&flags) {
             return Err(error_invalid_data("XZ stream header CRC32 mismatch"));
         }
+
+        // The first byte and the upper nibble of the second byte are reserved.
+        // The checksum check comes first. A corrupt header is reported as
+        // corrupt and not as unsupported.
+        if flags[0] != 0 || flags[1] & 0xF0 != 0 {
+            return Err(error_unsupported("invalid XZ stream flags"));
+        }
+
+        let check_type = CheckType::from_byte(flags[1])?;
 
         Ok(StreamHeader { check_type })
     }

--- a/src/xz/reader.rs
+++ b/src/xz/reader.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     CountingReader, Lzma2Reader, Read, Result,
     crc::Crc32,
-    error_eof, error_invalid_data, error_out_of_memory,
+    error_eof, error_invalid_data, error_out_of_memory, error_unsupported,
     filter::{FilterConfig, FilterType, StreamFilter, bcj::BcjReader, delta::DeltaReader},
     lzma2_reader::{Lzma2Stream, get_stream_memory_usage},
     stream::{Action, Status, StreamResult},
@@ -914,14 +914,17 @@ impl XzStream {
         if data[..6] != XZ_MAGIC {
             return Err(error_invalid_data("invalid XZ magic bytes"));
         }
-        if data[6] != 0 {
-            return Err(error_invalid_data("invalid XZ stream flags"));
-        }
-        let check_type = CheckType::from_byte(data[7])?;
         let expected_crc = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
         if expected_crc != Crc32::checksum(&data[6..8]) {
             return Err(error_invalid_data("XZ stream header CRC32 mismatch"));
         }
+        // The first byte and the upper nibble of the second byte are reserved.
+        // The checksum check comes first. A corrupt header is reported as
+        // corrupt and not as unsupported.
+        if data[6] != 0 || data[7] & 0xF0 != 0 {
+            return Err(error_unsupported("invalid XZ stream flags"));
+        }
+        let check_type = CheckType::from_byte(data[7])?;
         self.check_type = Some(check_type);
         self.index_records.clear();
         self.block_count = 0;
@@ -1187,12 +1190,9 @@ impl XzStream {
             return Err(error_invalid_data("invalid XZ footer magic"));
         }
         if data[8] != 0 {
-            return Err(error_invalid_data(
-                "reserved stream footer flags byte is non-zero",
-            ));
+            return Err(error_invalid_data("stream footer flags don't match header"));
         }
-        let footer_check_type = CheckType::from_byte(data[9])?;
-        if Some(footer_check_type) != self.check_type {
+        if self.check_type.map(|check_type| check_type as u8) != Some(data[9]) {
             return Err(error_invalid_data("stream footer flags don't match header"));
         }
 

--- a/tests/xz_stream.rs
+++ b/tests/xz_stream.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 
 use lzma_rust2::{Action, Status, XzOptions, XzStream, XzWriter};
 
@@ -604,4 +604,122 @@ fn memory_limit_matches_the_dictionary_in_the_block_header() {
         .process(&compressed, &mut output_buf, Action::Finish)
         .unwrap_err();
     assert_eq!(error.kind(), std::io::ErrorKind::OutOfMemory);
+}
+
+/// Decodes until the stream fails, and returns why. Panics if it is accepted.
+fn stream_error(data: &[u8]) -> std::io::Error {
+    let mut decoder = XzStream::new(false);
+    let mut output = [0u8; 4096];
+    let mut in_pos = 0;
+
+    for _ in 0..64 {
+        match decoder.process(&data[in_pos..], &mut output, Action::Finish) {
+            Ok(result) => {
+                in_pos += result.bytes_consumed;
+                assert_ne!(result.status, Status::StreamEnd, "the stream was accepted");
+            }
+            Err(error) => return error,
+        }
+    }
+    panic!("the stream neither ended nor failed");
+}
+
+/// A valid stream, and the same stream cut inside its LZMA2 chunk. The chunk
+/// header declares more data than is handed over. The core cannot lean on the
+/// length and still holds bytes back when the input runs out.
+fn whole_and_cut_inside_the_lzma2_chunk(data: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    let stream = encode_xz(data, 1);
+    // Stream header, block header and LZMA2 chunk header are 12 + 12 + 6 bytes.
+    assert!(
+        stream[24] >= 0xC0,
+        "expected an LZMA2 chunk that carries properties"
+    );
+    assert!(
+        stream.len() > 30 + 500 + 20,
+        "the chunk is too short to cut"
+    );
+
+    let cut = stream[..30 + 500].to_vec();
+    (stream, cut)
+}
+
+/// Damages each of the twenty bytes that can still be held back, one at a time,
+/// and splits the positions by verdict: corrupt data, or a stream cut short.
+/// Positions count back from the end. `1` is the last byte handed over.
+fn split_held_back_damage(stream: &[u8]) -> (Vec<usize>, Vec<usize>) {
+    let mut corrupt = Vec::new();
+    let mut short = Vec::new();
+
+    for back in 1..=20 {
+        let mut damaged = stream.to_vec();
+        let at = damaged.len() - back;
+        damaged[at] ^= 0xFF;
+
+        let error = stream_error(&damaged);
+        if error.kind() == ErrorKind::UnexpectedEof {
+            short.push(back);
+        } else {
+            corrupt.push(back);
+        }
+    }
+
+    (corrupt, short)
+}
+
+/// The held back bytes have to be decoded once the caller says the input ended.
+/// A symbol that is already in hand and already broken is otherwise reported as
+/// a stream that was cut short. Which positions carry one is a property of this
+/// stream. All twenty are damaged and the split is pinned.
+#[test]
+fn finish_reports_corrupt_data_in_the_held_back_input() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (whole, cut) = whole_and_cut_inside_the_lzma2_chunk(&data);
+    let (corrupt, _) = split_held_back_damage(&cut);
+
+    assert_eq!(
+        corrupt,
+        [10, 12, 13, 16, 17, 18],
+        "the damage the decoder can already see changed"
+    );
+
+    // The broken symbol lies entirely in the bytes handed over. The same
+    // damage in the whole stream fails in the same way.
+    for back in corrupt {
+        let at = cut.len() - back;
+
+        let mut damaged_cut = cut.clone();
+        damaged_cut[at] ^= 0xFF;
+        let cut_error = stream_error(&damaged_cut);
+
+        let mut damaged_whole = whole.clone();
+        damaged_whole[at] ^= 0xFF;
+        let whole_error = stream_error(&damaged_whole);
+
+        assert_eq!(cut_error.kind(), whole_error.kind(), "byte {back} back");
+        assert_eq!(
+            cut_error.to_string(),
+            whole_error.to_string(),
+            "byte {back} back"
+        );
+    }
+}
+
+/// The other half of that decision. A symbol that can only be finished by
+/// reading the zero padding is no evidence that the data is wrong, only that
+/// the stream stops too early.
+#[test]
+fn finish_reports_a_short_stream_when_the_held_back_symbol_needs_more_input() {
+    let data = std::fs::read(INPUT_HTML).unwrap();
+    let (_, cut) = whole_and_cut_inside_the_lzma2_chunk(&data);
+
+    let error = stream_error(&cut);
+    assert_eq!(error.kind(), ErrorKind::UnexpectedEof, "{error}");
+
+    let (_, short) = split_held_back_damage(&cut);
+
+    assert_eq!(
+        short,
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 14, 15, 19, 20],
+        "damage the decoder cannot make out on its own was reported as corrupt"
+    );
 }

--- a/tests/xz_stream.rs
+++ b/tests/xz_stream.rs
@@ -1,6 +1,6 @@
 use std::io::{ErrorKind, Read, Write};
 
-use lzma_rust2::{Action, Status, XzOptions, XzStream, XzWriter};
+use lzma_rust2::{Action, Status, XzOptions, XzReader, XzStream, XzWriter};
 
 static EXECUTABLE: &str = "tests/data/executable.exe";
 static PG100: &str = "tests/data/pg100.txt";
@@ -722,4 +722,58 @@ fn finish_reports_a_short_stream_when_the_held_back_symbol_needs_more_input() {
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 14, 15, 19, 20],
         "damage the decoder cannot make out on its own was reported as corrupt"
     );
+}
+
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFFu32;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+/// The block header follows the 12 byte stream header. Its first byte gives the
+/// size, its last four bytes the CRC32 of the rest.
+fn repair_block_header_crc(stream: &mut [u8]) {
+    let size = (stream[12] as usize + 1) * 4;
+    let end = 12 + size;
+    let crc = crc32(&stream[12..end - 4]).to_le_bytes();
+    stream[end - 4..end].copy_from_slice(&crc);
+}
+
+/// The same bytes through the reader, which shares the header parsing.
+fn reader_error(data: &[u8]) -> std::io::Error {
+    let mut decompressed = Vec::new();
+    XzReader::new(data, false)
+        .read_to_end(&mut decompressed)
+        .expect_err("the stream was accepted")
+}
+
+/// Bits 2-5 of the block flags are reserved. A set bit means the header has an
+/// unknown field. It should not be parsed.
+#[test]
+fn block_flags_reserved_bits_are_rejected() {
+    for bits in [0x04u8, 0x08, 0x10, 0x20, 0x3C] {
+        let mut stream = encode_xz(b"block flags", 1);
+        stream[13] |= bits;
+        repair_block_header_crc(&mut stream);
+
+        assert_eq!(stream_error(&stream).kind(), ErrorKind::Unsupported);
+        assert_eq!(reader_error(&stream).kind(), ErrorKind::Unsupported);
+    }
+}
+
+/// The header checksum is verified first. A damaged header is reported as
+/// corrupt and not as unsupported.
+#[test]
+fn a_broken_block_header_checksum_comes_before_the_reserved_bits() {
+    let mut stream = encode_xz(b"block flags", 1);
+    stream[13] |= 0x3C;
+
+    assert_eq!(stream_error(&stream).kind(), ErrorKind::InvalidData);
+    assert_eq!(reader_error(&stream).kind(), ErrorKind::InvalidData);
 }

--- a/tests/xz_stream.rs
+++ b/tests/xz_stream.rs
@@ -777,3 +777,33 @@ fn a_broken_block_header_checksum_comes_before_the_reserved_bits() {
     assert_eq!(stream_error(&stream).kind(), ErrorKind::InvalidData);
     assert_eq!(reader_error(&stream).kind(), ErrorKind::InvalidData);
 }
+
+/// The stream header flags sit at offset 6, their CRC32 right behind them.
+fn repair_stream_header_crc(stream: &mut [u8]) {
+    let crc = crc32(&stream[6..8]).to_le_bytes();
+    stream[8..12].copy_from_slice(&crc);
+}
+
+/// The first byte of the stream flags is reserved, and so is the upper nibble
+/// of the second one, which holds the check type.
+#[test]
+fn stream_flags_reserved_bits_are_rejected() {
+    for (offset, bits) in [(6usize, 0x01u8), (6, 0x80), (7, 0x10), (7, 0xF0)] {
+        let mut stream = encode_xz(b"stream flags", 1);
+        stream[offset] |= bits;
+        repair_stream_header_crc(&mut stream);
+
+        assert_eq!(stream_error(&stream).kind(), ErrorKind::Unsupported);
+        assert_eq!(reader_error(&stream).kind(), ErrorKind::Unsupported);
+    }
+}
+
+/// The same for the stream header.
+#[test]
+fn a_broken_stream_header_checksum_comes_before_the_reserved_bits() {
+    let mut stream = encode_xz(b"stream flags", 1);
+    stream[6] |= 0x01;
+
+    assert_eq!(stream_error(&stream).kind(), ErrorKind::InvalidData);
+    assert_eq!(reader_error(&stream).kind(), ErrorKind::InvalidData);
+}


### PR DESCRIPTION
This PR includes the following changes:

- A corrupt LZMA2 chunk that arrived whole was reported by the sans-I/O decoders as a short stream. The core now decodes what it holds back immediately once the caller says the input ended, which helps produce the correct error.
- A block header with certain reserved flag bits set was decoded normally, through every reader. Both parsers now refuse it, as the spec requires.
- A set reserved bit currently produces InvalidData error. The format checksums those flags separately so a decoder can tell a corrupt file from an unsupported one, and a set reserved bit fits an `Unsupported` error better.