### PR TITLE
Fix multi-threaded readers degrading to serial decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `Lzma2ReaderMt`, `XzReaderMt` and `LzipReaderMt` no longer degrade to single-threaded decoding.
+
 ## 0.20.1 - 2026-08-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Lzma2ReaderMt`, `XzReaderMt` and `LzipReaderMt` no longer degrade to single-threaded decoding.
+- `Lzma2ReaderMt` and `XzReaderMt` no longer degrade to single-threaded decoding.
 
 ## 0.20.1 - 2026-08-30
 

--- a/src/lzma2_reader_mt.rs
+++ b/src/lzma2_reader_mt.rs
@@ -223,14 +223,14 @@ impl<R: Read> Lzma2ReaderMt<R> {
             );
         }
 
-        // We spawn a new thread if we have work queued, no available workers, and haven't reached
-        // the maximal allowed parallelism yet.
         let spawned_workers = self.worker_handles.len() as u32;
         let active_workers = self.active_workers.load(Ordering::Acquire);
         let queue_len = self.work_queue.len();
 
-        if queue_len > 0 && active_workers == spawned_workers && spawned_workers < self.max_workers
-        {
+        // Spawn another worker when more units are queued than there are idle ones. A parked
+        // worker that has not stolen its unit yet still counts as idle.
+        let idle_workers = spawned_workers.saturating_sub(active_workers) as usize;
+        if queue_len > idle_workers && spawned_workers < self.max_workers {
             self.spawn_worker_thread();
         }
 
@@ -278,8 +278,9 @@ impl<R: Read> Lzma2ReaderMt<R> {
                         }
                     }
 
-                    // If the work queue has capacity, try to read more from the source.
-                    if self.work_queue.is_empty() {
+                    // Read ahead while fewer units are queued than there are workers. Blocking as
+                    // soon as the queue is non-empty stalls the reader behind a single worker.
+                    if self.work_queue.len() < self.max_workers as usize {
                         match self.read_and_dispatch_chunk() {
                             Ok(true) => {
                                 // Successfully read and dispatched a chunk, loop to continue.

--- a/src/work_pool.rs
+++ b/src/work_pool.rs
@@ -222,8 +222,9 @@ where
                         }
                     }
 
-                    // If the work queue has capacity, try to read more from the source.
-                    if self.work_queue.len() < 2 {
+                    // Dispatch ahead while fewer items are queued than there are workers. Blocking
+                    // as soon as the queue is non-empty stalls dispatch behind a single worker.
+                    if self.work_queue.len() < self.num_workers as usize {
                         match self.dispatch_next_work(&mut next_work_function) {
                             Ok(true) => {
                                 // Successfully read and dispatched a chunk, loop to continue.
@@ -359,12 +360,10 @@ where
         let active_workers = self.active_workers.load(Ordering::Acquire);
         let queue_len = self.work_queue.len();
 
-        // Spawn a new worker if:
-        // 1. There's work in the queue
-        // 2. All current workers are busy (active == spawned)
-        // 3. We haven't reached the maximum worker count
-        if queue_len > 0 && active_workers == spawned_workers && spawned_workers < self.num_workers
-        {
+        // Spawn another worker when more items are queued than there are idle ones. A parked
+        // worker that has not stolen its item yet still counts as idle.
+        let idle_workers = spawned_workers.saturating_sub(active_workers) as usize;
+        if queue_len > idle_workers && spawned_workers < self.num_workers {
             self.spawn_worker_thread();
         }
     }

--- a/src/xz/reader_mt.rs
+++ b/src/xz/reader_mt.rs
@@ -245,14 +245,14 @@ impl<R: Read + Seek> XzReaderMt<R> {
             ));
         }
 
-        // We spawn a new thread if we have work queued, no available workers, and haven't reached
-        // the maximal allowed parallelism yet.
         let spawned_workers = self.worker_handles.len() as u32;
         let active_workers = self.active_workers.load(Ordering::Acquire);
         let queue_len = self.work_queue.len();
 
-        if queue_len > 0 && active_workers == spawned_workers && spawned_workers < self.max_workers
-        {
+        // Spawn another worker when more blocks are queued than there are idle ones. A parked
+        // worker that has not stolen its block yet still counts as idle.
+        let idle_workers = spawned_workers.saturating_sub(active_workers) as usize;
+        if queue_len > idle_workers && spawned_workers < self.max_workers {
             self.spawn_worker_thread();
         }
 
@@ -301,8 +301,9 @@ impl<R: Read + Seek> XzReaderMt<R> {
                         }
                     }
 
-                    // If the work queue has capacity, try to read more from the source.
-                    if self.work_queue.is_empty() {
+                    // Read ahead while fewer blocks are queued than there are workers. Blocking as
+                    // soon as the queue is non-empty stalls the reader behind a single worker.
+                    if self.work_queue.len() < self.max_workers as usize {
                         match self.dispatch_next_block() {
                             Ok(true) => {
                                 // Successfully read and dispatched a block, loop to continue.


### PR DESCRIPTION
# Fix multi-threaded readers degrading to serial decoding

## Problem

`Lzma2ReaderMt` (and `XzReaderMt` / `WorkPool`, which share the same dispatch loop) run at
single-thread speed no matter how many workers are requested. Decoding a 128 MiB LZMA2
stream written by 7-Zip with `-m0=lzma2:d=4m` (8 independent 16 MiB units) on a 14-core
machine:

| threads | wall (before) | user CPU |
|---|---|---|
| 1 | 0.903 s | 0.90 s |
| 8 | 0.875 s | 0.86 s |
| 14 | 0.894 s | 0.87 s |

`user ≈ real` in every row: only one thread ever decodes at a time. Sampling shows all
workers parked in the queue's condvar and the main thread in `recv_timeout`.

## Root cause

`get_next_uncompressed_chunk` only reads ahead while the work queue is **empty** and
otherwise blocks until a *result* arrives:

```rust
if self.work_queue.is_empty() {
    read_and_dispatch_chunk()...; continue;
}
// Now we MUST wait for a result to make progress.
loop { self.result_rx.recv_timeout(...) ... }
```

Right after `send_work_unit` pushes a unit, the queue stays non-empty for the few
microseconds it takes the notified worker to wake up and `steal()` it. The main thread
re-checks the queue immediately after pushing, so it almost always loses that race, sees
"queue non-empty", and blocks until the unit it just pushed has been fully decoded. Every
other worker idles meanwhile. On top of that, workers are only spawned when
`active_workers == spawned_workers` at push time; under the same race the freshly parked
worker is still counted as idle, so the pool never grows.

Trace of the old code (instrumented locally; `push` = main thread, `start`/`done` = worker):

```
[   733us] push seq=0 queue_len=1 active=0 spawned=1
[   734us] worker: start seq=0
[  1394us] push seq=1 queue_len=1 active=1 spawned=1   -> spawn worker #2
[  1427us] main: blocking wait, queue_len=1            <- lost the race, blocks ~118 ms
[119454us] worker: done seq=1
[119897us] worker: done seq=0
[122364us] push seq=2 ...                              <- next round, +1 worker at best
```

## Fix

* Read ahead while fewer units are queued than there are workers. The look-ahead is
  bounded by `num_workers` units of *compressed* data; the decompressed side is unchanged
  (one result per worker in flight plus the existing out-of-order map).
* Spawn a worker whenever more units are queued than there are idle workers
  (`spawned - active`). `active_workers` is only raised after a worker stole a unit, so a
  parked worker that has not woken up yet still counts as idle and is not doubled up.

Same change applied to `WorkPool::get_result` / `maybe_spawn_worker` (used by
`LzipReaderMt` and the MT writers) and to `XzReaderMt`.

## Result

| threads | before | after |
|---|---|---|
| 1 | 0.903 s | 0.885 s |
| 2 | 0.669 s | 0.449 s |
| 4 | 0.774 s | 0.239 s |
| 8 | 0.875 s | 0.130 s |
| 14 | 0.894 s | 0.130 s |

User CPU time stays at ~0.9 s in every row (no extra work, just overlap).

## Tests

`cargo test --release --features std,encoder,xz,lzip`: lzma / lzma2 / lzma2_mt /
lzma2_stream / lzip / lzip_mt / xz / xz_mt / xz_stream / multi_writer / regression /
unwind_safe all pass (macOS arm64, rustc 1.98).
